### PR TITLE
Fix Community Typo

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -613,13 +613,13 @@
     "message": "Self-Hosted with Additional Enterprise Features",
     "description": "Description for Databend Enterprise product"
   },
-  "Databend Cummunity": {
-    "message": "Databend Cummunity",
-    "description": "Title for Databend Cummunity product"
+  "Databend Community": {
+    "message": "Databend Community",
+    "description": "Title for Databend Community product"
   },
   "Self-Hosted & Free": {
     "message": "Self-Hosted & Free",
-    "description": "Description for Databend Cummunity product"
+    "description": "Description for Databend Community product"
   },
   "Create a Databend Cloud account or deploy your own Databend instance.": {
     "message": "Create a Databend Cloud account or deploy your own Databend instance.",

--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -625,7 +625,7 @@
     "message": "自托管与额外的企业功能",
     "description": "Databend Enterprise 产品的描述"
   },
-  "Databend Cummunity": {
+  "Databend Community": {
     "message": "Databend 社区版",
     "description": "Databend 社区版 产品的标题"
   },

--- a/src/components/DocsOverview/index.tsx
+++ b/src/components/DocsOverview/index.tsx
@@ -85,7 +85,7 @@ const DocsOverview: FC = (): ReactElement => {
             <Col {...colLayout3}>
               <Card href="/guides/overview/editions/dce/" padding={[16, 16]}>
                 <h3>
-                  <span>{$t("Databend Cummunity")}</span>
+                  <span>{$t("Databend Community")}</span>
                 </h3>
                 <div>{$t("Self-Hosted & Free")}</div>
               </Card>


### PR DESCRIPTION
This fixes a typo in the docs ("Cummunity" -> "Community").

<img width="1792" alt="Screenshot 2024-12-08 at 1 17 37 AM" src="https://github.com/user-attachments/assets/20391d7c-c642-4b47-b8f6-2ebc9ebb387b">