### PR TITLE
fix deploying databend on k8s add namespace databend-meta

### DIFF
--- a/docs/cn/guides/10-deploy/01-deploy/02-production/02-deploying-databend-on-kubernetes.md
+++ b/docs/cn/guides/10-deploy/01-deploy/02-production/02-deploying-databend-on-kubernetes.md
@@ -248,6 +248,7 @@ config:
   meta:
     # Set endpoints to use remote meta service
     # depends on previous deployed meta service、namespace and nodes
+    namespace: "databend-meta"
     endpoints:
       - "databend-meta-0.databend-meta.databend-meta.svc:9191"
       - "databend-meta-1.databend-meta.databend-meta.svc:9191"

--- a/docs/en/guides/10-deploy/01-deploy/02-production/02-deploying-databend-on-kubernetes.md
+++ b/docs/en/guides/10-deploy/01-deploy/02-production/02-deploying-databend-on-kubernetes.md
@@ -250,6 +250,7 @@ config:
   meta:
     # Set endpoints to use remote meta service
     # depends on previous deployed meta service、namespace and nodes
+    namespace: "databend-meta"
     endpoints:
       - "databend-meta-0.databend-meta.databend-meta.svc:9191"
       - "databend-meta-1.databend-meta.databend-meta.svc:9191"


### PR DESCRIPTION
I added namespace "databend-meta" based on the above contents because there was an error that prevented access to the meta node when I access query node without accidentally specifying the namespace databend-meta.

"ERROR databend_common_meta_client::established_client: established_client.rs:73 fail to update leader: "node(databend-meta-2.databend-meta.databend-meta.svc.cluster.local:9191) to set is not in the nodes list"; endpoints: current:Some("databend-meta-0.databend-meta.databend-meta.svc:9191"), all:[databend-meta-0.databend-meta.databend-meta.svc:9191, databend-meta-1.databend-meta.databend-meta.svc:9191, databend-meta-2.databend-meta.databend-meta.svc:9191]"