### PR TITLE
docs: extract supports EPOCH

### DIFF
--- a/docs/en/sql-reference/20-sql-functions/05-datetime-functions/extract.md
+++ b/docs/en/sql-reference/20-sql-functions/05-datetime-functions/extract.md
@@ -4,7 +4,7 @@ title: EXTRACT
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.153"/>
+<FunctionDescription description="Introduced or updated: v1.2.692"/>
 
 Retrieves the designated portion of a date, time, or timestamp.
 
@@ -13,57 +13,38 @@ See also: [DATE_PART](date-part.md)
 ## Syntax
 
 ```sql
-EXTRACT( YEAR | QUARTER | MONTH | WEEK | DAY | HOUR | MINUTE | SECOND | DOW | DOY FROM <date_or_time_expr> )
+EXTRACT( YEAR | QUARTER | MONTH | WEEK | DAY | HOUR | MINUTE | SECOND | DOW | DOY | EPOCH FROM <date_or_time_expr> )
 ```
 
-- DOW: Day of the Week.
-- DOY: Day of Year.
+- `DOW`: Day of the Week.
+- `DOY`: Day of the Year.
+- `EPOCH`: The number of seconds since 1970-01-01 00:00:00.
 
 ## Return Type
 
-Integer.
+The return type depends on the field being extracted:
+
+- Returns Integer: When extracting discrete date or time components (e.g., YEAR, MONTH, DAY, DOY, HOUR, MINUTE, SECOND), the function returns an Integer.
+
+    ```sql
+    SELECT EXTRACT(DAY FROM now());  -- Returns Integer
+    SELECT EXTRACT(DOY FROM now());  -- Returns Integer
+    ```
+
+- Returns Float: When extracting EPOCH (the number of seconds since 1970-01-01 00:00:00 UTC), the function returns a Float, as it may include fractional seconds.
+
+    ```sql
+    SELECT EXTRACT(EPOCH FROM now());  -- Returns Float
+    ```
 
 ## Examples
 
 ```sql
-SELECT NOW();
+SELECT NOW(), EXTRACT(DAY FROM NOW()), EXTRACT(DOY FROM NOW()), EXTRACT(EPOCH FROM NOW());
 
-┌────────────────────────────┐
-│            now()           │
-├────────────────────────────┤
-│ 2024-05-22 03:00:35.977589 │
-└────────────────────────────┘
-
-SELECT EXTRACT(DAY FROM NOW());
-
-┌─────────────────────────┐
-│ extract(day from now()) │
-├─────────────────────────┤
-│                      22 │
-└─────────────────────────┘
-
-SELECT EXTRACT(DOW FROM NOW());
-
-┌─────────────────────────┐
-│ extract(dow from now()) │
-├─────────────────────────┤
-│                       3 │
-└─────────────────────────┘
-
-SELECT EXTRACT(DOY FROM NOW());
-
-┌─────────────────────────┐
-│ extract(doy from now()) │
-├─────────────────────────┤
-│                     143 │
-└─────────────────────────┘
-
-SELECT EXTRACT(MONTH FROM TO_DATE('2022-05-13'));
-
-┌───────────────────────────────────────────┐
-│ extract(month from to_date('2022-05-13')) │
-│                   UInt8                   │
-├───────────────────────────────────────────┤
-│                                         5 │
-└───────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│            now()           │ EXTRACT(DAY FROM now()) │ EXTRACT(DOY FROM now()) │ EXTRACT(EPOCH FROM now()) │
+├────────────────────────────┼─────────────────────────┼─────────────────────────┼───────────────────────────┤
+│ 2025-02-08 03:51:51.991167 │                       8 │                      39 │         1738986711.991167 │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
```sql
EXTRACT( YEAR | QUARTER | MONTH | WEEK | DAY | HOUR | MINUTE | SECOND | DOW | DOY | EPOCH FROM <date_or_time_expr> )
```
- `EPOCH`: The number of seconds since 1970-01-01 00:00:00.