### PR TITLE
docs: add map and array functions

### DIFF
--- a/docs/en/sql-reference/20-sql-functions/00-array-functions/arrays-zip.md
+++ b/docs/en/sql-reference/20-sql-functions/00-array-functions/arrays-zip.md
@@ -1,0 +1,39 @@
+---
+title: ARRAYS_ZIP
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.690"/>
+
+Merge multiple arrays into a single array tuple.
+
+## Syntax
+
+```sql
+ARRAYS_ZIP( <array1> [, ...] )
+```
+
+## Arguments
+
+| Arguments  | Description       |
+|------------|-------------------|
+| `<arrayN>` | The input ARRAYs. |
+
+:::note
+- The length of each array must be the same.
+:::
+
+## Return Type
+
+Array(Tuple).
+
+## Examples
+
+```sql
+SELECT ARRAYS_ZIP([1, 2, 3], ['a', 'b', 'c']);
+┌────────────────────────────────────────┐
+│ arrays_zip([1, 2, 3], ['a', 'b', 'c']) │
+├────────────────────────────────────────┤
+│ [(1,'a'),(2,'b'),(3,'c')]              │
+└────────────────────────────────────────┘
+```

--- a/docs/en/sql-reference/20-sql-functions/09-geometry-functions/st-geometryfromtext.md
+++ b/docs/en/sql-reference/20-sql-functions/09-geometry-functions/st-geometryfromtext.md
@@ -1,0 +1,5 @@
+---
+title: ST_GEOMETRYFROMTEXT
+---
+
+Alias for [ST_GEOMETRYFROMWKT](st-geometryfromwkt.md).

--- a/docs/en/sql-reference/20-sql-functions/09-geometry-functions/st-geomtryfromtext.md
+++ b/docs/en/sql-reference/20-sql-functions/09-geometry-functions/st-geomtryfromtext.md
@@ -1,5 +1,0 @@
----
-title: ST_GEOTRYMFROMTEXT
----
-
-Alias for [ST_GEOMTRYFROMWKT](st-geometryfromwkt.md).

--- a/docs/en/sql-reference/20-sql-functions/10-map-functions/map-delete.md
+++ b/docs/en/sql-reference/20-sql-functions/10-map-functions/map-delete.md
@@ -11,14 +11,16 @@ Returns an existing MAP with one or more keys removed.
 
 ```sql
 MAP_DELETE( <map>, <key1> [, <key2>, ... ] )
+MAP_DELETE( <map>, <array> )
 ```
 
 ## Arguments
 
-| Arguments | Description                                  |
-|-----------|----------------------------------------------|
-| `<map>`   | The MAP that contains the KEY to remove.     |
-| `<keyN>`  | The KEY to be omitted from the returned MAP. |
+| Arguments | Description                                            |
+|-----------|--------------------------------------------------------|
+| `<map>`   | The MAP that contains the KEY to remove.               |
+| `<keyN>`  | The KEYs to be omitted from the returned MAP.          |
+| `<array>` | The Array of KEYs to be omitted from the returned MAP. |
 
 :::note
 - The types of the key expressions and the keys in the map must be the same.
@@ -38,4 +40,11 @@ SELECT MAP_DELETE({'a':1,'b':2,'c':3}, 'a', 'c');
 ├───────────────────────────────────────────┤
 │ {'b':2}                                   │
 └───────────────────────────────────────────┘
+
+SELECT MAP_DELETE({'a':1,'b':2,'c':3}, ['a', 'b']);
+┌─────────────────────────────────────────────┐
+│ map_delete({'a':1,'b':2,'c':3}, ['a', 'b']) │
+├─────────────────────────────────────────────┤
+│ {'c':3}                                     │
+└─────────────────────────────────────────────┘
 ```

--- a/docs/en/sql-reference/20-sql-functions/10-map-functions/map-insert.md
+++ b/docs/en/sql-reference/20-sql-functions/10-map-functions/map-insert.md
@@ -1,0 +1,45 @@
+---
+title: MAP_INSERT
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.654"/>
+
+Returns a new MAP consisting of the input MAP with a new key-value pair inserted (an existing key updated with a new value).
+
+## Syntax
+
+```sql
+MAP_INSERT( <map>, <key>, <value> [, <updateFlag> ] )
+```
+
+## Arguments
+
+| Arguments      | Description                                                                                      |
+|----------------|--------------------------------------------------------------------------------------------------|
+| `<map>`        | The input MAP.                                                                                   |
+| `<key>`        | The new key to insert into the MAP.                                                              |
+| `<value>`      | The new value to insert into the MAP.                                                            |
+| `<updateFlag>` | The boolean flag identifies whether can overwrite the key that already exists. default is FALSE. |
+
+## Return Type
+
+Map.
+
+## Examples
+
+```sql
+SELECT MAP_INSERT({'a':1,'b':2,'c':3}, 'd', 4);
+┌─────────────────────────────────────────┐
+│ map_insert({'a':1,'b':2,'c':3}, 'd', 4) │
+├─────────────────────────────────────────┤
+│ {'a':1,'b':2,'c':3,'d':4}               │
+└─────────────────────────────────────────┘
+
+SELECT MAP_INSERT({'a':1,'b':2,'c':3}, 'a', 5, true);
+┌───────────────────────────────────────────────┐
+│ map_insert({'a':1,'b':2,'c':3}, 'a', 5, TRUE) │
+├───────────────────────────────────────────────┤
+│ {'a':5,'b':2,'c':3}                           │
+└───────────────────────────────────────────────┘
+```

--- a/docs/en/sql-reference/20-sql-functions/10-map-functions/map-pick.md
+++ b/docs/en/sql-reference/20-sql-functions/10-map-functions/map-pick.md
@@ -1,0 +1,50 @@
+---
+title: MAP_PICK
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.654"/>
+
+Returns a new MAP containing the specified key-value pairs from an existing MAP.
+
+## Syntax
+
+```sql
+MAP_PICK( <map>, <key1> [, <key2>, ... ] )
+MAP_PICK( <map>, <array> )
+```
+
+## Arguments
+
+| Arguments | Description                                             |
+|-----------|-------------------------------------------------------- |
+| `<map>`   | The input MAP.                                          |
+| `<keyN>`  | The KEYs to be included from the returned MAP.          |
+| `<array>` | The Array of KEYs to be included from the returned MAP. |
+
+:::note
+- The types of the key expressions and the keys in the map must be the same.
+- Key values not found in the map will be ignored.
+:::
+
+## Return Type
+
+Map.
+
+## Examples
+
+```sql
+SELECT MAP_PICK({'a':1,'b':2,'c':3}, 'a', 'c');
+┌─────────────────────────────────────────┐
+│ map_pick({'a':1,'b':2,'c':3}, 'a', 'c') │
+├─────────────────────────────────────────┤
+│ {'a':1,'c':3}                           │
+└─────────────────────────────────────────┘
+
+SELECT MAP_PICK({'a':1,'b':2,'c':3}, ['a', 'b']);
+┌───────────────────────────────────────────┐
+│ map_pick({'a':1,'b':2,'c':3}, ['a', 'b']) │
+├───────────────────────────────────────────┤
+│ {'a':1,'b':2}                             │
+└───────────────────────────────────────────┘
+```


### PR DESCRIPTION
add docs for following functions:

- `map_pick`
- `map_insert`
- `arrays_zip`

fix typos for `st-geomtryfromtext` function.
