### PR TITLE
docs: Attach tbl 

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/92-attach-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/92-attach-table.md
@@ -13,16 +13,17 @@ import EEFeature from '@site/src/components/EEFeature';
 
 Attaches an existing table to another one. The command moves the data and schema of a table from one database to another, but without actually copying the data. Instead, it creates a link that points to the original table data for accessing the data.
 
-Attach Table enables you to seamlessly connect a table in the cloud service platform to an existing table deployed in a private deployment environment without the need to physically move the data. This is particularly useful when you want to migrate data from a private deployment of Databend to [Databend Cloud](https://www.databend.com) while minimizing the data transfer overhead.
+- Attach Table enables you to seamlessly connect a table in the cloud service platform to an existing table deployed in a private deployment environment without the need to physically move the data. This is particularly useful when you want to migrate data from a private deployment of Databend to [Databend Cloud](https://www.databend.com) while minimizing the data transfer overhead.
 
-The attached table operates in READ_ONLY mode. In this mode, changes in the source table are instantly reflected in the attached table. However, the attached table is exclusively for querying purposes and does not support updates. This means INSERT, UPDATE, and DELETE operations are not allowed on the attached table; only SELECT queries can be executed.
+- The attached table operates in READ_ONLY mode. In this mode, changes in the source table are instantly reflected in the attached table. However, the attached table is exclusively for querying purposes and does not support updates. This means INSERT, UPDATE, and DELETE operations are not allowed on the attached table; only SELECT queries can be executed.
 
 ## Syntax
 
 ```sql
-ATTACH TABLE <target_table_name> '<source_table_data_URI>'
+ATTACH TABLE <target_table_name> [ ( <column_list> ) ] '<source_table_data_URI>'
 CONNECTION = ( <connection_parameters> )
 ```
+- `<column_list>`: An optional list of columns to include from the source table, allowing users to specify only the necessary columns instead of loading all available data. If not specified, all columns from the source table will be included.
 
 - `<source_table_data_URI>` represents the path to the source table's data. For S3-like object storage, the format is `s3://<bucket-name>/<database_ID>/<table_ID>`, for example, _s3://databend-toronto/1/23351/_, which represents the exact path to the table folder within the bucket.
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/92-attach-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/92-attach-table.md
@@ -5,7 +5,7 @@ sidebar_position: 6
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.549"/>
+<FunctionDescription description="Introduced or updated: v1.2.698"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/92-attach-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/92-attach-table.md
@@ -55,89 +55,28 @@ CONNECTION = ( <connection_parameters> )
 
 - `CONNECTION` specifies the connection parameters required for establishing a link to the object storage where the source table's data is stored. The connection parameters vary for different storage services based on their specific requirements and authentication mechanisms. For more information, see [Connection Parameters](../../../00-sql-reference/51-connect-parameters.md).
 
+## Tutorials
+
+- [Linking Tables with ATTACH TABLE](/tutorials/databend-cloud/link-tables)
+
 ## Examples
 
-This example illustrates how to link a new table in Databend Cloud with an existing table in Databend, which stores data within an Amazon S3 bucket named "databend-toronto".
+This example creates an attached table, which includes all columns from a source table stored in AWS S3:
 
-#### Step 1. Creating Table in Databend
-
-Create a table named "population" and insert some sample data:
-
-```sql title='Databend:'
-CREATE TABLE population (
-  city VARCHAR(50),
-  population INT
-);
-
-INSERT INTO population (city, population) VALUES
-  ('Toronto', 2731571),
-  ('Montreal', 1704694),
-  ('Vancouver', 631486);
-```
-
-#### Step 2. Obtaining Database ID and Table ID
-
-Use the [FUSE_SNAPSHOT](../../../20-sql-functions/16-system-functions/fuse_snapshot.md) function to obtain the database ID and table ID. The result below indicates that the database ID is **1**, and the table ID is **556**:
-
-```sql title='Databend:'
-SELECT * FROM FUSE_SNAPSHOT('default', 'population');
-
-┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│            snapshot_id           │                 snapshot_location                 │ format_version │ previous_snapshot_id │ segment_count │ block_count │ row_count │ bytes_uncompressed │ bytes_compressed │ index_size │          timestamp         │
-├──────────────────────────────────┼───────────────────────────────────────────────────┼────────────────┼──────────────────────┼───────────────┼─────────────┼───────────┼────────────────────┼──────────────────┼────────────┼────────────────────────────┤
-│ f252dd43d1aa44898a04827808342daf │ 1/556/_ss/f252dd43d1aa44898a04827808342daf_v4.mpk │              4 │ NULL                 │             1 │           1 │         3 │                 70 │              448 │        531 │ 2023-11-01 02:35:47.325319 │
-└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-```
-
-When you access the bucket page on Amazon S3, you'll observe that the data is organized within the path `databend-toronto` > `1` > `556`, like this:
-
-![Alt text](/img/sql/attach-table-2.png)
-
-#### Step 3. Linking Table in Databend Cloud
-
-Sign in to Databend Cloud and run the following command in a worksheet to link a table named "population_readonly":
-
-```sql title='Databend Cloud:'
-ATTACH TABLE population_readonly 's3://databend-toronto/1/556/' CONNECTION = (
+```sql
+ATTACH TABLE population_all_columns 's3://databend-doc/1/16/' CONNECTION = (
+  REGION='us-east-2',
   AWS_KEY_ID = '<your_aws_key_id>',
   AWS_SECRET_KEY = '<your_aws_secret_key>'
 );
 ```
 
-To verify the success of the link, run the following query in Databend Cloud:
+This example creates an attached table, which includes only selected columns (`city` and `population`) from a source table stored in AWS S3:
 
-```sql title='Databend Cloud:'
-SELECT * FROM population_readonly;
-
--- Expected result:
-┌────────────────────────────────────┐
-│       city       │    population   │
-├──────────────────┼─────────────────┤
-│ Toronto          │         2731571 │
-│ Montreal         │         1704694 │
-│ Vancouver        │          631486 │
-└────────────────────────────────────┘
-```
-
-You're all set! If you update the source table in Databend, you can observe the same changes reflected in the target table on Databend Cloud. For example, if you change the population of Toronto to 2,371,571 in the source table:
-
-```sql title='Databend:'
-UPDATE population
-SET population = 2371571
-WHERE city = 'Toronto';
-```
-
-You can see that the updates are synced to the attached table in Databend Cloud:
-
-```sql title='Databend Cloud:'
-SELECT * FROM population_readonly;
-
--- Expected result:
-┌────────────────────────────────────┐
-│       city       │    population   │
-├──────────────────┼─────────────────┤
-│ Toronto          │         2371571 │
-│ Montreal         │         1704694 │
-│ Vancouver        │          631486 │
-└────────────────────────────────────┘
+```sql
+ATTACH TABLE population_only (city, population) 's3://databend-doc/1/16/' CONNECTION = (
+  REGION='us-east-2',
+  AWS_KEY_ID = '<your_aws_key_id>',
+  AWS_SECRET_KEY = '<your_aws_secret_key>'
+);
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/92-attach-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/92-attach-table.md
@@ -23,7 +23,11 @@ Attaches an existing table to another one. The command moves the data and schema
 ATTACH TABLE <target_table_name> [ ( <column_list> ) ] '<source_table_data_URI>'
 CONNECTION = ( <connection_parameters> )
 ```
-- `<column_list>`: An optional list of columns to include from the source table, allowing users to specify only the necessary columns instead of loading all available data. If not specified, all columns from the source table will be included.
+- `<column_list>`: An optional, comma-separated list of columns to include from the source table, allowing users to specify only the necessary columns instead of including all of them. If not specified, all columns from the source table will be included.
+
+  - Renaming an included column in the source table updates its name in the attached table, and it must be accessed using the new name.
+  - Dropping an included column in the source table makes it inaccessible in the attached table.
+  - Changes to non-included columns, such as renaming or dropping them in the source table, do not affect the attached table.
 
 - `<source_table_data_URI>` represents the path to the source table's data. For S3-like object storage, the format is `s3://<bucket-name>/<database_ID>/<table_ID>`, for example, _s3://databend-toronto/1/23351/_, which represents the exact path to the table folder within the bucket.
 

--- a/docs/en/tutorials/databend-cloud/link-tables.md
+++ b/docs/en/tutorials/databend-cloud/link-tables.md
@@ -1,0 +1,116 @@
+---
+title: Linking Tables with ATTACH TABLE
+---
+
+In this tutorial, we'll walk you through how to link a table in Databend Cloud with an existing Databend table stored in an S3 bucket using the ATTACH TABLE command.
+
+## Before You Start
+
+Before you start, ensure you have the following prerequisites in place:
+
+- [Docker](https://www.docker.com/) is installed on your local machine, as it will be used to launch a self-hosted Databend.
+- An AWS S3 bucket used as storage for your self-hosted Databend. [Learn how to create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html).
+- AWS Access Key ID and Secret Access Key with sufficient permissions for accessing your S3 bucket. [Manage your AWS credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
+- BendSQL is installed on your local machine. See [Installing BendSQL](/guides/sql-clients/bendsql/#installing-bendsql) for instructions on how to install BendSQL using various package managers.
+
+## Step 1: Launch Databend in Docker
+
+1. Start a Databend container on your local machine. The command below launches a Databend container with S3 as the storage backend, using the `databend-doc` bucket, along with the specified S3 endpoint and authentication credentials.
+
+```bash
+docker run \
+    -p 8000:8000 \
+    -e QUERY_STORAGE_TYPE=s3 \
+    -e AWS_S3_ENDPOINT="https://s3.us-east-2.amazonaws.com" \
+    -e AWS_S3_BUCKET=databend-doc\
+    -e AWS_ACCESS_KEY_ID=<your-aws-access-key-id> \ # Replace with your AWS access key ID
+    -e AWS_SECRET_ACCESS_KEY=<your-aws-secrect-access-key> \ # Replace with your AWS secret access key
+    datafuselabs/databend:v1.2.699-nightly
+```
+
+2. Create a table named `population` to store city, province, and population data, and insert sample records as follows:
+
+```sql
+CREATE TABLE population (
+  city VARCHAR(50),
+  province VARCHAR(50),  
+  population INT
+);
+
+INSERT INTO population (city, province, population) VALUES
+  ('Toronto', 'Ontario', 2731571),
+  ('Montreal', 'Quebec', 1704694),
+  ('Vancouver', 'British Columbia', 631486);
+```
+
+3. Run the following statement to retrieve the table's location in S3. As indicated in the result below, the S3 URI for the table is `s3://databend-doc/1/16/` for this tutorial.
+
+```sql
+SELECT snapshot_location FROM FUSE_SNAPSHOT('default', 'population');
+
+┌──────────────────────────────────────────────────┐
+│                 snapshot_location                │
+├──────────────────────────────────────────────────┤
+│ 1/16/_ss/513c5100aa0243fe863b4cc2df0e3046_v4.mpk │
+└──────────────────────────────────────────────────┘
+```
+
+## Step 2: Set Up Attached Tables in Databend Cloud
+
+1. Connect to Databend Cloud using BendSQL. If you're unfamiliar with BendSQL, refer to this tutorial: [Connecting to Databend Cloud using BendSQL](../connect/connect-to-databendcloud-bendsql.md).
+
+2. Execute the following statements to create two attached tables:
+    - The first table, `population_all_columns`, includes all columns from the source data.
+    - The second table, `population_withoutprovince`, includes only the selected columns (city & population).
+
+```sql
+-- Create an attached table with all columns from the source
+ATTACH TABLE population_all_columns 's3://databend-doc/1/16/' CONNECTION = (
+  REGION='us-east-2',
+  AWS_KEY_ID = '<your_aws_key_id>',
+  AWS_SECRET_KEY = '<your_aws_secret_key>'
+);
+
+-- Create an attached table with selected columns (city & population) from the source
+ATTACH TABLE population_withoutprovince (city, population) 's3://databend-doc/1/16/' CONNECTION = (
+  REGION='us-east-2',
+  AWS_KEY_ID = '<your_aws_key_id>',
+  AWS_SECRET_KEY = '<your_aws_secret_key>'
+);
+```
+
+## Step 3: Verify Attached Tables
+
+1. Query the two attached tables to verify their contents:
+
+```sql
+SELECT * FROM population_all_columns;
+
+┌───────────────────────────────────────────────────────┐
+│       city       │     province     │    population   │
+├──────────────────┼──────────────────┼─────────────────┤
+│ Toronto          │ Ontario          │         2731571 │
+│ Montreal         │ Quebec           │         1704694 │
+│ Vancouver        │ British Columbia │          631486 │
+└───────────────────────────────────────────────────────┘
+
+SELECT * FROM population_withoutprovince;
+
+┌────────────────────────────────────┐
+│       city       │    population   │
+├──────────────────┼─────────────────┤
+│ Toronto          │         2731571 │
+│ Montreal         │         1704694 │
+│ Vancouver        │          631486 │
+└────────────────────────────────────┘
+```
+
+2. If you update the source table in Databend, you can observe the same changes reflected in the attached table on Databend Cloud. For example, if you change the population of Toronto to 2,371,571 in the source table:
+
+```sql
+UPDATE population
+SET population = 2371571
+WHERE city = 'Toronto';
+```
+
+    After executing the update, you can query the attached table again to see the updated data:


### PR DESCRIPTION
Added the ability to specify selected cols when attaching a table:

- Updated ATTACH TABLE syntax:

  ```sql
  ATTACH TABLE <target_table_name> [ ( <column_list> ) ] '<source_table_data_URI>'
  CONNECTION = ( <connection_parameters> )
  ```
- Updated ATTACH TABLE examples.
- Added a new tutorial: Linking Tables with ATTACH TABLE