### PR TITLE
docs: illegal characters for user o role name 

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.566"/>
+<FunctionDescription description="Introduced or updated: v1.2.703"/>
 
 Creates a SQL user.
 
@@ -25,6 +25,11 @@ CREATE [ OR REPLACE ] USER <name> IDENTIFIED [ WITH <auth_type> ] BY '<password>
 [ WITH DISABLED = true | false ] -- User created in a disabled state
 ```
 
+- The `<name>` cannot contain the following illegal characters:
+    - Single quote (')
+    - Double quote (")
+    - Backspace (\b)
+    - Form feed (\f)
 - *auth_type* can be `double_sha1_password` (default), `sha256_password` or `no_password`.
 - When `MUST_CHANGE_PASSWORD` is set to `true`, the new user must change password at first login. Users can change their own password using the [ALTER USER](03-user-alter-user.md) command.
 - When you set a default role for a user using CREATE USER or [ALTER USER](03-user-alter-user.md), Databend does not verify the role's existence or automatically grant the role to the user. You must explicitly grant the role to the user for the role to take effect.

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/04-user-create-role.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/04-user-create-role.md
@@ -2,8 +2,11 @@
 title: CREATE ROLE
 sidebar_position: 5
 ---
+import FunctionDescription from '@site/src/components/FunctionDescription';
 
-Create a new role.
+<FunctionDescription description="Introduced or updated: v1.2.703"/>
+
+Creates a new role.
 
 After creating roles, you can grant object privileges to the role, enable access control security for objects in the system.
 
@@ -12,8 +15,15 @@ See also: [GRANT](10-grant.md)
 ## Syntax
 
 ```sql
-CREATE ROLE [ IF NOT EXISTS ] <role_name> [ COMMENT = '<string_literal>' ]
+CREATE ROLE [ IF NOT EXISTS ] <name> [ COMMENT = '<string_literal>' ]
 ```
+
+- The `<name>` cannot contain the following illegal characters:
+    - Single quote (')
+    - Double quote (")
+    - Backspace (\b)
+    - Form feed (\f)
+
 ## Examples
 
 ```sql


### PR DESCRIPTION
A SQL user or role name cannot contain the following illegal characters:
    - Single quote (')
    - Double quote (")
    - Backspace (\b)
    - Form feed (\f)