### PR TITLE
Fix: Update jaeger.md

### DIFF
--- a/docs/en/guides/10-deploy/03-monitor/tools/jaeger.md
+++ b/docs/en/guides/10-deploy/03-monitor/tools/jaeger.md
@@ -42,7 +42,7 @@ docker run --rm -d --name jaeger \
 ...
 [log.tracing]
 capture_log_level = "DEBUG"
-on = "true"
+on = true
 otlp_endpoint = "http://127.0.0.1:4317"
 ...
 ```


### PR DESCRIPTION
databend-query version: v1.2.731-nightly

Databend Query start failure, cause: anyhow. Code: 1002, Text = TOML parse error at line 105, column 6
    |
105 | on = "true"
    |      ^^^^^^
invalid type: string "true", expected a boolean
, source: None
TOML parse error at line 105, column 6
    |
105 | on = "true"
    |      ^^^^^^
invalid type: string "true", expected a boolean
