### PR TITLE
docs: function alias

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/04-task/01-ddl-create_task.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/04-task/01-ddl-create_task.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.371"/>
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
 
 The CREATE TASK statement is used to define a new task that executes a specified SQL statement on a scheduled basis or dag based task graph.
 
@@ -14,7 +14,7 @@ The CREATE TASK statement is used to define a new task that executes a specified
 ## Syntax
 
 ```sql
-CREATE TASK [ IF NOT EXISTS ] <name>
+CREATE [ OR REPLACE ] TASK [ IF NOT EXISTS ] <name>
  WAREHOUSE = <string>
  SCHEDULE = { <num> MINUTE | <num> SECOND | USING CRON <expr> <time_zone> }
  [ AFTER <string> [ , <string> , ... ]]

--- a/docs/en/sql-reference/10-sql-commands/10-dml/dml-insert-multi.md
+++ b/docs/en/sql-reference/10-sql-commands/10-dml/dml-insert-multi.md
@@ -4,7 +4,7 @@ title: INSERT (multi-table)
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.738"/>
+<FunctionDescription description="Introduced or updated: v1.2.396"/>
 
 Inserts rows into multiple tables in a single transaction, with the option for the insertion to be dependent on certain conditions (conditionally) or to occur regardless of any conditions (unconditionally).
 
@@ -18,14 +18,14 @@ See also: [INSERT](dml-insert.md)
 
 ```sql
 -- Unconditional INSERT ALL: Inserts each row into multiple tables without any conditions or restrictions.
-INSERT [ OVERWRITE [ INTO ] ] ALL
+INSERT [ OVERWRITE ] ALL
     INTO <target_table> [ ( <target_col_name> [ , ... ] ) ] [ VALUES ( <source_col_name> [ , ... ] ) ]
     ...
 SELECT ...
 
 
 -- Conditional INSERT ALL: Inserts each row into multiple tables, but only if certain conditions are met.
-INSERT [ OVERWRITE [ INTO ] ] ALL
+INSERT [ OVERWRITE ] ALL
     WHEN <condition> THEN
         INTO <target_table> [ ( <target_col_name> [ , ... ] ) ] [ VALUES ( <source_col_name> [ , ... ] ) ]
       [ INTO ... ]
@@ -37,7 +37,7 @@ SELECT ...
 
 
 -- Conditional INSERT FIRST: Inserts each row into multiple tables, but stops after the first successful insertion.
-INSERT [ OVERWRITE [ INTO ] ] FIRST
+INSERT [ OVERWRITE ] FIRST
     WHEN <condition> THEN
         INTO <target_table> [ ( <target_col_name> [ , ... ] ) ] [ VALUES ( <source_col_name> [ , ... ] ) ]
       [ INTO ... ]
@@ -50,7 +50,7 @@ SELECT ...
 
 | Parameter                                | Description                                                                                                                                                                                                                                                                                                                                           |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OVERWRITE [ INTO ]`                     | Indicates whether existing data should be truncated before insertion.                                                                                                                                                                                                                                                                                 |
+| `OVERWRITE`                              | Indicates whether existing data should be truncated before insertion.                                                                                                                                                                                                                                                                                 |
 | `( <target_col_name> [ , ... ] )`        | Specifies the column names in the target table where data will be inserted.<br/>- If omitted, data will be inserted into all columns in the target table.                                                                                                                                                                                             |
 | `VALUES ( <source_col_name> [ , ... ] )` | Specifies the source column names from which data will be inserted into the target table.<br/>- If omitted, all columns returned by the subquery will be inserted into the target table.<br/>- The data types of the columns listed in `<source_col_name>` must match or be compatible with those specified in `<target_col_name>`.                   |
 | `SELECT ...`                             | A subquery that provides the data to be inserted into the target table(s).<br/>- You have the option to explicitly assign aliases to columns within the subquery. This allows you to reference the columns by their aliases within WHEN clauses and VALUES clauses.                                                                                   |

--- a/docs/en/sql-reference/10-sql-commands/10-dml/dml-insert-multi.md
+++ b/docs/en/sql-reference/10-sql-commands/10-dml/dml-insert-multi.md
@@ -4,7 +4,7 @@ title: INSERT (multi-table)
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.396"/>
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
 
 Inserts rows into multiple tables in a single transaction, with the option for the insertion to be dependent on certain conditions (conditionally) or to occur regardless of any conditions (unconditionally).
 
@@ -18,14 +18,14 @@ See also: [INSERT](dml-insert.md)
 
 ```sql
 -- Unconditional INSERT ALL: Inserts each row into multiple tables without any conditions or restrictions.
-INSERT [ OVERWRITE ] ALL
+INSERT [ OVERWRITE [ INTO ] ] ALL
     INTO <target_table> [ ( <target_col_name> [ , ... ] ) ] [ VALUES ( <source_col_name> [ , ... ] ) ]
     ...
 SELECT ...
 
 
 -- Conditional INSERT ALL: Inserts each row into multiple tables, but only if certain conditions are met.
-INSERT [ OVERWRITE ] ALL
+INSERT [ OVERWRITE [ INTO ] ] ALL
     WHEN <condition> THEN
         INTO <target_table> [ ( <target_col_name> [ , ... ] ) ] [ VALUES ( <source_col_name> [ , ... ] ) ]
       [ INTO ... ]
@@ -37,7 +37,7 @@ SELECT ...
 
 
 -- Conditional INSERT FIRST: Inserts each row into multiple tables, but stops after the first successful insertion.
-INSERT [ OVERWRITE ] FIRST
+INSERT [ OVERWRITE [ INTO ] ] FIRST
     WHEN <condition> THEN
         INTO <target_table> [ ( <target_col_name> [ , ... ] ) ] [ VALUES ( <source_col_name> [ , ... ] ) ]
       [ INTO ... ]
@@ -50,13 +50,12 @@ SELECT ...
 
 | Parameter                                | Description                                                                                                                                                                                                                                                                                                                                           |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OVERWRITE                                | Indicates whether existing data should be truncated before insertion.                                                                                                                                                                                                                                                                                 |
+| `OVERWRITE [ INTO ]`                     | Indicates whether existing data should be truncated before insertion.                                                                                                                                                                                                                                                                                 |
 | `( <target_col_name> [ , ... ] )`        | Specifies the column names in the target table where data will be inserted.<br/>- If omitted, data will be inserted into all columns in the target table.                                                                                                                                                                                             |
-| VALUES `( <source_col_name> [ , ... ] )` | Specifies the source column names from which data will be inserted into the target table.<br/>- If omitted, all columns returned by the subquery will be inserted into the target table.<br/>- The data types of the columns listed in `<source_col_name>` must match or be compatible with those specified in `<target_col_name>`.                   |
-| SELECT ...                               | A subquery that provides the data to be inserted into the target table(s).<br/>- You have the option to explicitly assign aliases to columns within the subquery. This allows you to reference the columns by their aliases within WHEN clauses and VALUES clauses.                                                                                   |
-| WHEN                                     | Conditional statement to determine when to insert data into specific target tables.<br/>- A conditional multi-table insert requires at least one WHEN clause.<br/>- A WHEN clause can include multiple INTO clauses, and these INTO clauses can target the same table.<br/>- To unconditionally execute a WHEN clause, you can use `WHEN 1 THEN ...`. |
-| ELSE                                     | Specifies the action to take if none of the conditions specified in the WHEN clauses are met.                                                                                                                                                                                                                                                         |
-
+| `VALUES ( <source_col_name> [ , ... ] )` | Specifies the source column names from which data will be inserted into the target table.<br/>- If omitted, all columns returned by the subquery will be inserted into the target table.<br/>- The data types of the columns listed in `<source_col_name>` must match or be compatible with those specified in `<target_col_name>`.                   |
+| `SELECT ...`                             | A subquery that provides the data to be inserted into the target table(s).<br/>- You have the option to explicitly assign aliases to columns within the subquery. This allows you to reference the columns by their aliases within WHEN clauses and VALUES clauses.                                                                                   |
+| `WHEN`                                   | Conditional statement to determine when to insert data into specific target tables.<br/>- A conditional multi-table insert requires at least one WHEN clause.<br/>- A WHEN clause can include multiple INTO clauses, and these INTO clauses can target the same table.<br/>- To unconditionally execute a WHEN clause, you can use `WHEN 1 THEN ...`. |
+| `ELSE`                                   | Specifies the action to take if none of the conditions specified in the WHEN clauses are met.                                                                                                                                                                                                                                                        |
 ## Important Notes
 
 - Aggregate functions, external UDFs, and window functions are not allowed in the `VALUES(...)` expressions.

--- a/docs/en/sql-reference/10-sql-commands/10-dml/dml-insert.md
+++ b/docs/en/sql-reference/10-sql-commands/10-dml/dml-insert.md
@@ -1,6 +1,9 @@
 ---
 title: INSERT
 ---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
 
 Inserts one or more rows into a table.
 
@@ -13,7 +16,7 @@ See also: [INSERT (multi-table)](dml-insert-multi.md)
 ## Syntax
 
 ```sql
-INSERT { OVERWRITE | INTO } <table>
+INSERT { OVERWRITE [ INTO ] | INTO } <table>
     -- Optionally specify the columns to insert into
     ( <column> [ , ... ] )
     -- Insertion options:
@@ -25,10 +28,10 @@ INSERT { OVERWRITE | INTO } <table>
     }
 ```
 
-| Parameter | Description                                                                      |
-|-----------|----------------------------------------------------------------------------------|
-| OVERWRITE | Indicates whether existing data should be truncated before insertion.            |
-| VALUES    | Allows direct insertion of specific values or the default values of the columns. |
+| Parameter          | Description                                                                      |
+|--------------------|----------------------------------------------------------------------------------|
+| `OVERWRITE [INTO]` | Indicates whether existing data should be truncated before insertion.            |
+| `VALUES`           | Allows direct insertion of specific values or the default values of the columns. |
 
 ## Important Notes
 

--- a/docs/en/sql-reference/20-sql-functions/03-conditional-functions/greatest-ignore-nulls.md
+++ b/docs/en/sql-reference/20-sql-functions/03-conditional-functions/greatest-ignore-nulls.md
@@ -1,0 +1,30 @@
+---
+title: GREATEST_IGNORE_NULLS
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Returns the maximum value from a set of values, ignoring any NULL values.
+
+See also: [GREATEST](greatest.md)
+
+## Syntax
+
+```sql
+GREATEST_IGNORE_NULLS(<value1>, <value2> ...)
+```
+
+## Examples
+
+```sql
+SELECT GREATEST_IGNORE_NULLS(5, 9, 4), GREATEST_IGNORE_NULLS(5, 9, null);
+```
+
+```sql
+┌────────────────────────────────────────────────────────────────────┐
+│ greatest_ignore_nulls(5, 9, 4) │ greatest_ignore_nulls(5, 9, NULL) │
+├────────────────────────────────┼───────────────────────────────────┤
+│                              9 │                                 9 │
+└────────────────────────────────────────────────────────────────────┘
+```

--- a/docs/en/sql-reference/20-sql-functions/03-conditional-functions/greatest.md
+++ b/docs/en/sql-reference/20-sql-functions/03-conditional-functions/greatest.md
@@ -1,8 +1,13 @@
 ---
 title: GREATEST
 ---
+import FunctionDescription from '@site/src/components/FunctionDescription';
 
-Returns the maximum value from a set of values.
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Returns the maximum value from a set of values. If any value in the set is `NULL`, the function returns `NULL`.
+
+See also: [GREATEST_IGNORE_NULLS](greatest-ignore-nulls.md)
 
 ## Syntax
 
@@ -13,11 +18,13 @@ GREATEST(<value1>, <value2> ...)
 ## Examples
 
 ```sql
-SELECT GREATEST(5, 9, 4);
+SELECT GREATEST(5, 9, 4), GREATEST(5, 9, null);
+```
 
-┌───────────────────┐
-│ greatest(5, 9, 4) │
-├───────────────────┤
-│                 9 │
-└───────────────────┘
+```sql
+┌──────────────────────────────────────────┐
+│ greatest(5, 9, 4) │ greatest(5, 9, NULL) │
+├───────────────────┼──────────────────────┤
+│                 9 │ NULL                 │
+└──────────────────────────────────────────┘
 ```

--- a/docs/en/sql-reference/20-sql-functions/03-conditional-functions/if.md
+++ b/docs/en/sql-reference/20-sql-functions/03-conditional-functions/if.md
@@ -3,7 +3,7 @@ title: IF
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.1.738"/>
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
 
 If `<cond1>` is TRUE, it returns `<expr1>`. Otherwise if `<cond2>` is TRUE, it returns `<expr2>`, and so on.
 

--- a/docs/en/sql-reference/20-sql-functions/03-conditional-functions/if.md
+++ b/docs/en/sql-reference/20-sql-functions/03-conditional-functions/if.md
@@ -1,6 +1,9 @@
 ---
 title: IF
 ---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.1.738"/>
 
 If `<cond1>` is TRUE, it returns `<expr1>`. Otherwise if `<cond2>` is TRUE, it returns `<expr2>`, and so on.
 
@@ -9,6 +12,10 @@ If `<cond1>` is TRUE, it returns `<expr1>`. Otherwise if `<cond2>` is TRUE, it r
 ```sql
 IF(<cond1>, <expr1>, [<cond2>, <expr2> ...], <expr_else>)
 ```
+
+## Aliases
+
+- [IFF](iff.md)
 
 ## Examples
 

--- a/docs/en/sql-reference/20-sql-functions/03-conditional-functions/iff.md
+++ b/docs/en/sql-reference/20-sql-functions/03-conditional-functions/iff.md
@@ -3,6 +3,6 @@ title: IFF
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.1.738"/>
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
 
 Alias for [IF](if.md).

--- a/docs/en/sql-reference/20-sql-functions/03-conditional-functions/iff.md
+++ b/docs/en/sql-reference/20-sql-functions/03-conditional-functions/iff.md
@@ -1,0 +1,8 @@
+---
+title: IFF
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.1.738"/>
+
+Alias for [IF](if.md).

--- a/docs/en/sql-reference/20-sql-functions/03-conditional-functions/least-ignore-nulls.md
+++ b/docs/en/sql-reference/20-sql-functions/03-conditional-functions/least-ignore-nulls.md
@@ -1,0 +1,30 @@
+---
+title: LEAST_IGNORE_NULLS
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Returns the maximum value from a set of values, ignoring any NULL values.
+
+See also: [LEAST](least.md)
+
+## Syntax
+
+```sql
+LEAST_IGNORE_NULLS(<value1>, <value2> ...)
+```
+
+## Examples
+
+```sql
+SELECT LEAST_IGNORE_NULLS(5, 9, 4), LEAST_IGNORE_NULLS(5, 9, null);
+```
+
+```sql
+┌──────────────────────────────────────────────────────────────┐
+│ least_ignore_nulls(5, 9, 4) │ least_ignore_nulls(5, 9, NULL) │
+├─────────────────────────────┼────────────────────────────────┤
+│                           4 │                              5 │
+└──────────────────────────────────────────────────────────────┘
+```

--- a/docs/en/sql-reference/20-sql-functions/03-conditional-functions/least.md
+++ b/docs/en/sql-reference/20-sql-functions/03-conditional-functions/least.md
@@ -1,8 +1,13 @@
 ---
 title: LEAST
 ---
+import FunctionDescription from '@site/src/components/FunctionDescription';
 
-Returns the minimum value from a set of values.
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Returns the minimum value from a set of values. If any value in the set is `NULL`, the function returns `NULL`.
+
+See also: [LEAST_IGNORE_NULLS](least-ignore-nulls.md)
 
 ## Syntax
 
@@ -13,11 +18,13 @@ LEAST(<value1>, <value2> ...)
 ## Examples
 
 ```sql
-SELECT LEAST(5, 9, 4);
+SELECT LEAST(5, 9, 4), LEAST(5, 9, null);
+```
 
-┌────────────────┐
-│ least(5, 9, 4) │
-├────────────────┤
-│              4 │
-└────────────────┘
+```
+┌────────────────────────────────────┐
+│ least(5, 9, 4) │ least(5, 9, NULL) │
+├────────────────┼───────────────────┤
+│              4 │ NULL              │
+└────────────────────────────────────┘
 ```

--- a/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-covar-pop.md
+++ b/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-covar-pop.md
@@ -1,8 +1,11 @@
 ---
 title: COVAR_POP
 ---
+import FunctionDescription from '@site/src/components/FunctionDescription';
 
-COVAR_POP returns the population covariance of a set of number pairs. 
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Returns the population covariance of a set of number pairs. 
 
 ## Syntax
 
@@ -16,6 +19,11 @@ COVAR_POP(<expr1>, <expr2>)
 |-----------| ------------------------ |
 | `<expr1>` | Any numerical expression |
 | `<expr2>` | Any numerical expression |
+
+## Aliases
+
+- [VAR_POP](aggregate-var-pop.md)
+- [VARIANCE_POP](aggregate-variance-pop.md)
 
 ## Return Type
 

--- a/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-covar-samp.md
+++ b/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-covar-samp.md
@@ -2,9 +2,11 @@
 title: COVAR_SAMP
 ---
 
-Aggregate function.
+import FunctionDescription from '@site/src/components/FunctionDescription';
 
-The covar_samp() function returns the sample covariance (Σ((x - x̅)(y - y̅)) / (n - 1)) of two data columns.
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Returns the sample covariance (Σ((x - x̅)(y - y̅)) / (n - 1)) of two data columns.
 
 :::caution
 NULL values are not counted.
@@ -22,6 +24,11 @@ COVAR_SAMP(<expr1>, <expr2>)
 | --------- | ------------------------ |
 | `<expr1>` | Any numerical expression |
 | `<expr2>` | Any numerical expression |
+
+## Aliases
+
+- [VAR_SAMP](aggregate-var-samp.md)
+- [VARIANCE_SAMP](aggregate-variance-samp.md)
 
 ## Return Type
 

--- a/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-var-pop.md
+++ b/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-var-pop.md
@@ -1,0 +1,8 @@
+---
+title: VAR_POP
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Alias for [COVAR_POP](aggregate-covar-pop.md).

--- a/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-var-samp.md
+++ b/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-var-samp.md
@@ -1,0 +1,9 @@
+---
+title: VAR_SAMP
+---
+
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Alias for [COVAR_SAMP](aggregate-covar-samp.md).

--- a/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-variance-pop.md
+++ b/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-variance-pop.md
@@ -1,0 +1,8 @@
+---
+title: VARIANCE_POP
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Alias for [COVAR_POP](aggregate-covar-pop.md).

--- a/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-variance-samp.md
+++ b/docs/en/sql-reference/20-sql-functions/07-aggregate-functions/aggregate-variance-samp.md
@@ -1,0 +1,9 @@
+---
+title: VARIANCE_SAMP
+---
+
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.738"/>
+
+Alias for [COVAR_SAMP](aggregate-covar-samp.md).


### PR DESCRIPTION
This change is related to https://github.com/databendlabs/databend/pull/17920:
- Support CREATE OR REPLACE syntax for tasks
- IFF is now an alias for the IF function
- GREATEST and LEAST will now return NULL if any input argument is NULL
- Added GREATEST_IGNORE_NULLS and LEAST_IGNORE_NULLS, which ignore NULL values (same behavior as the previous GREATEST and LEAST)
- Added VAR_POP and VARIANCE_POP as aliases for the COVAR_POP function
- Added VAR_SAMP and VARIANCE_SAMP as aliases for the COVAR_SAMP function
- Support INSERT OVERWRITE INTO syntax (equivalent to INSERT OVERWRITE)