### PR TITLE
date time: introduce the trunc and date_format_style

### DIFF
--- a/docs/en/sql-reference/00-sql-reference/31-system-tables/system-settings.md
+++ b/docs/en/sql-reference/00-sql-reference/31-system-tables/system-settings.md
@@ -3,7 +3,7 @@ title: system.settings
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.466"/>
+<FunctionDescription description="Introduced or updated: v1.2.745"/>
 
 Stores the system settings of the current session.
 
@@ -13,6 +13,7 @@ SELECT * FROM system.settings;
 name                                        |value       |default     |level  |description                                                                                                                                                                        |type  |
 --------------------------------------------+------------+------------+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------+
 collation                                   |binary      |binary      |SESSION|Sets the character collation. Available values include "binary" and "utf8".                                                                                                        |String|
+date_format_style                           |MySQL       |MySQL       |SESSION|Sets the date format style for datetime functions. Available values: "MySQL" (using %Y, %m format) and "Oracle" (using YYYY, MM format for standard SQL compatibility).            |String|
 ddl_column_type_nullable                    |1           |1           |SESSION|If columns are default nullable when create or alter table                                                                                                                         |UInt64|
 efficiently_memory_group_by                 |0           |0           |SESSION|Memory is used efficiently, but this may cause performance degradation.                                                                                                            |UInt64|
 enable_aggregating_index_scan               |1           |1           |SESSION|Enable scanning aggregating index data while querying.                                                                                                                             |UInt64|
@@ -78,4 +79,4 @@ table_lock_expire_secs                      |5           |5           |SESSION|S
 timezone                                    |Japan       |UTC         |GLOBAL |Sets the timezone.                                                                                                                                                                 |String|
 unquoted_ident_case_sensitive               |0           |0           |SESSION|Determines whether Databend treats unquoted identifiers as case-sensitive.                                                                                                         |UInt64|
 use_parquet2                                |1           |1           |SESSION|Use parquet2 instead of parquet_rs when infer_schema().                                                                                                                            |UInt64|
-```
+week_start                                  |1           |1           |SESSION|Specifies the first day of the week (Used by week-related date functions). 0 for Sunday, 1 for Monday.                                                                             |UInt64|

--- a/docs/en/sql-reference/10-sql-commands/20-query-syntax/settings.md
+++ b/docs/en/sql-reference/10-sql-commands/20-query-syntax/settings.md
@@ -65,8 +65,51 @@ SETTINGS (timezone = 'America/Toronto') SELECT timezone(), now();
 └──────────────────────────────────────────────┘
 ```
 
+This example demonstrates how to use the date_format_style setting to switch between MySQL and Oracle date formatting styles:
+
+```sql
+-- Default MySQL style date formatting
+SELECT to_string('2024-04-05'::DATE, '%b');
+
+┌────────────────────────────────┐
+│ to_string('2024-04-05', '%b')  │
+├────────────────────────────────┤
+│ Apr                            │
+└────────────────────────────────┘
+
+-- Oracle style date formatting
+SETTINGS (date_format_style = 'Oracle') SELECT to_string('2024-04-05'::DATE, 'MON');
+
+┌────────────────────────────────┐
+│ to_string('2024-04-05', 'MON') │
+├────────────────────────────────┤
+│ Apr                            │
+└────────────────────────────────┘
+```
+
+This example shows how the week_start setting affects week-related date functions:
+
+```sql
+-- Default week_start = 1 (Monday as first day of week)
+SELECT date_trunc(WEEK, to_date('2024-04-03'));  -- Wednesday
+
+┌────────────────────────────────────────┐
+│ date_trunc(WEEK, to_date('2024-04-03')) │
+├────────────────────────────────────────┤
+│ 2024-04-01                             │
+└────────────────────────────────────────┘
+
+-- Setting week_start = 0 (Sunday as first day of week)
+SETTINGS (week_start = 0) SELECT date_trunc(WEEK, to_date('2024-04-03'));  -- Wednesday
+
+┌────────────────────────────────────────┐
+│ date_trunc(WEEK, to_date('2024-04-03')) │
+├────────────────────────────────────────┤
+│ 2024-03-31                             │
+└────────────────────────────────────────┘
+```
+
 This example allows the COPY INTO operation to utilize up to 100 threads for parallel processing:
 
 ```sql
 SETTINGS (max_threads = 100) COPY INTO ...
-```

--- a/docs/en/sql-reference/20-sql-functions/02-conversion-functions/to-string.md
+++ b/docs/en/sql-reference/20-sql-functions/02-conversion-functions/to-string.md
@@ -2,6 +2,10 @@
 title: TO_STRING
 ---
 
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.745"/>
+
 Converts a value to String data type, or converts a Date value to a specific string format. To customize the format of date and time in Databend, you can utilize specifiers. These specifiers allow you to define the desired format for date and time values. For a comprehensive list of supported specifiers, see [Formatting Date and Time](../../00-sql-reference/10-data-types/datetime.md#formatting-date-and-time).
 
 ## Syntax
@@ -12,12 +16,53 @@ TO_STRING( '<expr>' )
 TO_STRING( '<date>', '<format>' )
 ```
 
+## Date Format Styles
+
+Databend supports two date format styles that can be selected using the `date_format_style` setting:
+
+- **MySQL** (default): Uses MySQL-compatible format specifiers like `%Y`, `%m`, `%d`, etc.
+- **Oracle**: Uses format specifiers like `YYYY`, `MM`, `DD`, etc., which follow a standardized format commonly used in many database systems.
+
+To switch between format styles, use the `date_format_style` setting:
+
+```sql
+-- Set Oracle-style date format
+SETTINGS (date_format_style = 'Oracle') SELECT to_string('2024-04-05'::DATE, 'YYYY-MM-DD');
+
+-- Set MySQL date format style (default)
+SETTINGS (date_format_style = 'MySQL') SELECT to_string('2024-04-05'::DATE, '%Y-%m-%d');
+```
+
+### Oracle-Style Format Specifiers
+
+When `date_format_style` is set to 'Oracle', the following format specifiers are supported:
+
+| Format Specifier | Description                                  | Example Output (for '2024-04-05 14:30:45.123456') |
+|------------------|----------------------------------------------|---------------------------------------------------|
+| YYYY             | 4-digit year                                 | 2024                                              |
+| YY               | 2-digit year                                 | 24                                                |
+| MMMM             | Full month name                              | April                                             |
+| MON              | Abbreviated month name                       | Apr                                               |
+| MM               | Month number (01-12)                         | 04                                                |
+| DD               | Day of month (01-31)                         | 05                                                |
+| DY               | Abbreviated day name                         | Fri                                               |
+| HH24             | Hour of day (00-23)                          | 14                                                |
+| HH12             | Hour of day (01-12)                          | 02                                                |
+| AM/PM            | Meridian indicator                           | PM                                                |
+| MI               | Minute (00-59)                               | 30                                                |
+| SS               | Second (00-59)                               | 45                                                |
+| FF               | Fractional seconds                           | 123456                                            |
+| UUUU             | ISO week-numbering year                      | 2024                                              |
+| TZH:TZM          | Time zone hour and minute with colon         | +08:00                                            |
+| TZH              | Time zone hour                               | +08                                               |
+
 ## Aliases
 
 - [DATE_FORMAT](../05-datetime-functions/date-format.md)
 - [JSON_TO_STRING](../10-semi-structured-functions/json-to-string.md)
 - [TO_TEXT](../02-conversion-functions/to-text.md)
 - [TO_VARCHAR](to-varchar.md)
+- TO_CHAR (Oracle compatibility)
 
 ## Return Type
 
@@ -66,6 +111,7 @@ SELECT
 │ 20223-12-25                │ 20223-12-25              │ 20223-12-25            │ 20223-12-25               │ 20223-12-25                   │
 └────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 
+-- Using MySQL format style (default)
 SELECT
   DATE_FORMAT('2022-12-25', '%m/%d/%Y'),
   TO_STRING('2022-12-25', '%m/%d/%Y'),
@@ -74,8 +120,20 @@ SELECT
   JSON_TO_STRING('2022-12-25', '%m/%d/%Y');
 
 ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ date_format('2022-12-25', '%m/%d/%y') │ to_string('2022-12-25', '%m/%d/%y') │ to_text('2022-12-25', '%m/%d/%y') │ to_varchar('2022-12-25', '%m/%d/%y') │ json_to_string('2022-12-25', '%m/%d/%y') │
+│ date_format('2022-12-25', '%m/%d/%Y') │ to_string('2022-12-25', '%m/%d/%Y') │ to_text('2022-12-25', '%m/%d/%Y') │ to_varchar('2022-12-25', '%m/%d/%Y') │ json_to_string('2022-12-25', '%m/%d/%Y') │
 ├───────────────────────────────────────┼─────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────────┤
 │ 12/25/2022                            │ 12/25/2022                          │ 12/25/2022                        │ 12/25/2022                           │ 12/25/2022                               │
 └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-```
+
+-- Using Oracle format style (same data as MySQL example above)
+SETTINGS (date_format_style = 'Oracle') 
+SELECT
+  TO_STRING('2022-12-25', 'MM/DD/YYYY'),
+  TO_CHAR('2022-12-25', 'MM/DD/YYYY');  -- Using TO_CHAR alias
+
+┌─────────────────────────────────────────────────────────────────┐
+│ to_string('2022-12-25', 'MM/DD/YYYY') │ to_char('2022-12-25', 'MM/DD/YYYY') │
+├─────────────────────────────────────┼───────────────────────────────────┤
+│ 12/25/2022                        │ 12/25/2022                        │
+
+└─────────────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/docs/en/sql-reference/20-sql-functions/05-datetime-functions/date-trunc.md
+++ b/docs/en/sql-reference/20-sql-functions/05-datetime-functions/date-trunc.md
@@ -3,9 +3,9 @@ title: DATE_TRUNC
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.697"/>
+<FunctionDescription description="Introduced or updated: v1.2.745"/>
 
-Truncates a date or timestamp to a specified precision. For example, if you truncate `2022-07-07` to `MONTH`, the result will be `2022-07-01`; if you truncate `2022-07-07 01:01:01.123456` to `SECOND`, the result will be `2022-07-07 01:01:01.000000`.
+Truncates a date or timestamp to a specified precision, providing a standardized way to manipulate dates and timestamps. This function is designed to be compatible with various database systems, making it easier for users to migrate and work with different databases.
 
 ## Syntax
 
@@ -17,6 +17,23 @@ DATE_TRUNC(<precision>, <date_or_timestamp>)
 |-----------------------|------------------------------------------------------------------------------------------------------------|
 | `<precision>`         | Must be of the following values: `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE` and `SECOND`. |
 | `<date_or_timestamp>` | A value of `DATE` or `TIMESTAMP` type.                                                                     |
+
+## Week Start Configuration
+
+When using `WEEK` as the precision parameter, the result depends on the `week_start` setting, which defines the first day of the week:
+
+- `week_start = 1` (default): Monday is considered the first day of the week
+- `week_start = 0`: Sunday is considered the first day of the week
+
+You can use the `SETTINGS` clause to change this setting for a specific query:
+
+```sql
+-- Set Sunday as the first day of the week
+SETTINGS (week_start = 0) SELECT DATE_TRUNC(WEEK, to_date('2024-04-05'));
+
+-- Set Monday as the first day of the week (default)
+SETTINGS (week_start = 1) SELECT DATE_TRUNC(WEEK, to_date('2024-04-05'));
+```
 
 ## Return Type
 
@@ -32,6 +49,22 @@ SELECT
 ┌────────────────────────────────────────────────────────────────────────────────────┐
 │ DATE_TRUNC(MONTH, to_date('2022-07-07')) │ DATE_TRUNC(WEEK, to_date('2022-07-07')) │
 ├──────────────────────────────────────────┼─────────────────────────────────────────┤
-│ 2022-07-01                               │ 2022-07-04                              │
+│ 2022-07-01                               │ 2022-07-04                               │
 └────────────────────────────────────────────────────────────────────────────────────┘
 ```
+
+```sql
+SELECT
+    DATE_TRUNC(HOUR, to_timestamp('2022-07-07 01:01:01.123456')),
+    DATE_TRUNC(SECOND, to_timestamp('2022-07-07 01:01:01.123456'));
+
+┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ DATE_TRUNC(HOUR, to_timestamp('2022-07-07 01:01:01.123456')) │ DATE_TRUNC(SECOND, to_timestamp('2022-07-07 01:01:01.123456')) │
+├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
+│ 2022-07-07 01:00:00.000000                                  │ 2022-07-07 01:01:01.000000                                     │
+└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## See Also
+
+- [TRUNC](trunc.md): Provides similar functionality with a different syntax for better SQL standard compatibility.

--- a/docs/en/sql-reference/20-sql-functions/05-datetime-functions/trunc.md
+++ b/docs/en/sql-reference/20-sql-functions/05-datetime-functions/trunc.md
@@ -1,0 +1,89 @@
+---
+title: TRUNC
+---
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced: v1.2.745"/>
+
+Truncates a date or timestamp to a specified precision. This function follows a widely adopted date truncation syntax, making it easier for users migrating from other database systems.
+
+## Syntax
+
+```sql
+TRUNC(<date_or_timestamp>, <datetime_interval_type>)
+```
+
+| Parameter                  | Description                                                                                                |
+|----------------------------|------------------------------------------------------------------------------------------------------------|
+| `<date_or_timestamp>`      | A value of `DATE` or `TIMESTAMP` type.                                                                     |
+| `<datetime_interval_type>` | Must be one of the following values: `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`. |
+
+## Week Start Configuration
+
+When using `WEEK` as the datetime interval type, the result depends on the `week_start` setting, which defines the first day of the week:
+
+- `week_start = 1` (default): Monday is considered the first day of the week
+- `week_start = 0`: Sunday is considered the first day of the week
+
+You can use the `SETTINGS` clause to change this setting for a specific query:
+
+```sql
+-- Set Sunday as the first day of the week
+SETTINGS (week_start = 0) SELECT TRUNC(to_date('2024-04-05'), 'WEEK');
+
+-- Set Monday as the first day of the week (default)
+SETTINGS (week_start = 1) SELECT TRUNC(to_date('2024-04-05'), 'WEEK');
+```
+
+## Return Type
+
+Same as `<date_or_timestamp>`.
+
+## Examples
+
+```sql
+-- Truncate to different precisions
+SELECT
+    TRUNC(to_date('2022-07-07'), 'MONTH'),
+    TRUNC(to_date('2022-07-07'), 'WEEK'),
+    TRUNC(to_date('2022-07-07'), 'YEAR');
+
+┌────────────────────────────────────────────────────────────────────────────────────┐
+│ TRUNC(to_date('2022-07-07'), 'MONTH') │ TRUNC(to_date('2022-07-07'), 'WEEK') │ TRUNC(to_date('2022-07-07'), 'YEAR') │
+├──────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┤
+│ 2022-07-01                           │ 2022-07-04                          │ 2022-01-01                          │
+└────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+The following example demonstrates how the `week_start` setting affects the result of `TRUNC` with `WEEK` precision:
+
+```sql
+-- Default: week_start = 1 (Monday as first day of week)
+SELECT TRUNC(to_date('2024-04-03'), 'WEEK');  -- Wednesday
+
+┌─────────────────────────────────────┐
+│ TRUNC(to_date('2024-04-03'), 'WEEK') │
+├─────────────────────────────────────┤
+│ 2024-04-01                          │ -- Monday
+└─────────────────────────────────────┘
+
+-- Setting week_start = 0 (Sunday as first day of week)
+SETTINGS (week_start = 0) SELECT TRUNC(to_date('2024-04-03'), 'WEEK');  -- Wednesday
+
+┌─────────────────────────────────────┐
+│ TRUNC(to_date('2024-04-03'), 'WEEK') │
+├─────────────────────────────────────┤
+│ 2024-03-31                          │ -- Sunday
+└─────────────────────────────────────┘
+```
+
+Using `TRUNC` with timestamp values:
+
+```sql
+SELECT TRUNC(to_timestamp('2022-07-07 15:30:45.123456'), 'DAY');
+
+┌───────────────────────────────────────────────────────┐
+│ TRUNC(to_timestamp('2022-07-07 15:30:45.123456'), 'DAY') │
+├───────────────────────────────────────────────────────┤
+│ 2022-07-07 00:00:00.000000                            │
+└───────────────────────────────────────────────────────┘


### PR DESCRIPTION
**Summary:**  
Add support for MySQL and Oracle-style date/time format specifiers and configurable week start day in Databend. Update documentation to cover new settings (`date_format_style`, `week_start`), with examples and compatibility notes. Introduce Oracle-compatible `TRUNC` function for date/time truncation.

**Highlights:**
- New settings: `date_format_style` (MySQL/Oracle), `week_start` (Sunday/Monday).
- Enhanced docs for formatting dates/times and week functions.
- Added `TRUNC` function (Oracle syntax) alongside `DATE_TRUNC`.
- Updated examples and tables for clarity and migration.