### PR TITLE
fix: restore WITH clause documentation and improve SQL reference pages

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
@@ -4,50 +4,59 @@ title: DDL (Data Definition Language) Commands
 
 These topics provide reference information for the DDL (Data Definition Language) commands in Databend.
 
-## Database and Table Management
+## Database & Table Management
 
-- [Database](00-database/index.md) 
-- [Table](01-table/index.md)
-- [View](05-view/index.md)
-- [Dictionary](17-dictionary/index.md)
+| Component | Description |
+|-----------|-------------|
+| **[Database](00-database/index.md)** | Create, alter, and drop databases |
+| **[Table](01-table/index.md)** | Create, alter, and manage tables |
+| **[View](05-view/index.md)** | Create and manage virtual tables based on queries |
+| **[Dictionary](17-dictionary/index.md)** | Create key-value lookup tables for data enrichment |
 
-## Database Performance and Indexing
+## Performance & Indexing
 
-- [Cluster Key](06-clusterkey/index.md)
-- [Aggregating Index](07-aggregating-index/index.md)
-- [Inverted Index](07-inverted-index/index.md)
-- [Ngram Index](07-ngram-index/index.md)
-- [Virtual Column](07-virtual-column/index.md)
+| Component | Description |
+|-----------|-------------|
+| **[Cluster Key](06-clusterkey/index.md)** | Define data clustering for query optimization |
+| **[Aggregating Index](07-aggregating-index/index.md)** | Pre-compute aggregations for faster queries |
+| **[Inverted Index](07-inverted-index/index.md)** | Full-text search index for text columns |
+| **[Ngram Index](07-ngram-index/index.md)** | Substring search index for LIKE patterns |
+| **[Virtual Column](07-virtual-column/index.md)** | Extract and index JSON fields as virtual columns |
 
-## User, Role, and Security Management
+## Security & Access Control
 
-- [User](02-user/index.md)
-- [Network Policy](12-network-policy/index.md)
-- [Mask Policy](12-mask-policy/index.md)
-- [Password Policy](12-password-policy/index.md)
+| Component | Description |
+|-----------|-------------|
+| **[User](02-user/index.md)** | Create and manage database users |
+| **[Network Policy](12-network-policy/index.md)** | Control network access to databases |
+| **[Mask Policy](12-mask-policy/index.md)** | Apply data masking for sensitive information |
+| **[Password Policy](12-password-policy/index.md)** | Enforce password requirements and rotation |
 
-## Data Staging and Processing
+## Data Integration & Processing
 
-- [Stage](03-stage/index.md)
-- [Stream](04-stream/index.md)
-- [Sequence](04-sequence/index.md)
-- [Task](04-task/index.md)
-- [Connection](13-connection/index.md)
-- [File Format](13-file-format/index.md)
+| Component | Description |
+|-----------|-------------|
+| **[Stage](03-stage/index.md)** | Define storage locations for data loading |
+| **[Stream](04-stream/index.md)** | Capture and process data changes |
+| **[Task](04-task/index.md)** | Schedule and automate SQL operations |
+| **[Sequence](04-sequence/index.md)** | Generate unique sequential numbers |
+| **[Connection](13-connection/index.md)** | Configure external data source connections |
+| **[File Format](13-file-format/index.md)** | Define formats for data import/export |
 
-## Transaction and Variable Management
+## Functions & Procedures
 
-- [Transaction](14-transaction/index.md)
-- [Variable](15-variable/index.md)
+| Component | Description |
+|-----------|-------------|
+| **[UDF](10-udf/index.md)** | Create custom functions in Python or JavaScript |
+| **[External Function](11-external-function/index.md)** | Integrate external APIs as SQL functions |
+| **[Procedure](18-procedure/index.md)** | Create stored procedures for complex logic |
+| **[Notification](16-notification/index.md)** | Set up event notifications and webhooks |
 
-## Function and External Integration
+## Resource Management
 
-- [UDF (User Defined Function)](10-udf/index.md)
-- [External Function](11-external-function/index.md)
-- [Procedure](18-procedure/index.md)
-- [Notification](16-notification/index.md)
-
-## Compute Resource Management
-
-- [Warehouse](19-warehouse/index.md)
-- [Workload Group](20-workload-group/index.md)
+| Component | Description |
+|-----------|-------------|
+| **[Warehouse](19-warehouse/index.md)** | Manage compute resources for query execution |
+| **[Workload Group](20-workload-group/index.md)** | Control resource allocation and priorities |
+| **[Transaction](14-transaction/index.md)** | Manage database transactions |
+| **[Variable](15-variable/index.md)** | Set and use session/global variables |

--- a/docs/en/sql-reference/10-sql-commands/10-dml/index.md
+++ b/docs/en/sql-reference/10-sql-commands/10-dml/index.md
@@ -1,8 +1,23 @@
 ---
 title: DML (Data Manipulation Language) Commands
 ---
-import IndexOverviewList from '@site/src/components/IndexOverviewList';
 
 This page provides reference information for the DML (Data Manipulation Language) commands in Databend.
 
-<IndexOverviewList />
+## Data Modification
+
+| Command | Description |
+|---------|-------------|
+| **[INSERT](dml-insert)** | Add new rows to a table |
+| **[INSERT MULTI](dml-insert-multi)** | Insert data into multiple tables in one statement |
+| **[UPDATE](dml-update)** | Modify existing rows in a table |
+| **[DELETE](dml-delete-from)** | Remove rows from a table |
+| **[REPLACE](dml-replace)** | Insert new rows or update existing ones |
+| **[MERGE](dml-merge)** | Perform upsert operations based on conditions |
+
+## Data Loading & Export
+
+| Command | Description |
+|---------|-------------|
+| **[COPY INTO Table](dml-copy-into-table)** | Load data from files into tables |
+| **[COPY INTO Location](dml-copy-into-location)** | Export table data to files |

--- a/docs/en/sql-reference/10-sql-commands/20-query-syntax/index.md
+++ b/docs/en/sql-reference/10-sql-commands/20-query-syntax/index.md
@@ -1,8 +1,59 @@
 ---
 title: Query Syntax
 ---
-import IndexOverviewList from '@site/src/components/IndexOverviewList';
 
-This page provides reference information for the query syntax in Databend.
+This page provides reference information for the query syntax in Databend. Each component can be used individually or combined to build powerful queries.
 
-<IndexOverviewList />
+## Core Query Components
+
+| Component | Description |
+|-----------|-------------|
+| **[SELECT](query-select)** | Retrieve data from tables - the foundation of all queries |
+| **[FROM / JOIN](query-join)** | Specify data sources and combine multiple tables |
+| **[WHERE](query-select#where-clause)** | Filter rows based on conditions |
+| **[GROUP BY](query-group-by)** | Group rows and perform aggregations (SUM, COUNT, AVG, etc.) |
+| **[HAVING](query-group-by#having-clause)** | Filter grouped results |
+| **[ORDER BY](query-select#order-by-clause)** | Sort query results |
+| **[LIMIT / TOP](top)** | Restrict the number of rows returned |
+
+## Advanced Features
+
+| Component | Description |
+|-----------|-------------|
+| **[WITH (CTE)](with-clause)** | Define reusable query blocks for complex logic |
+| **[PIVOT](query-pivot)** | Convert rows to columns (wide format) |
+| **[UNPIVOT](query-unpivot)** | Convert columns to rows (long format) |
+| **[QUALIFY](qualify)** | Filter rows after window function calculations |
+| **[VALUES](values)** | Create inline temporary data sets |
+
+## Time Travel & Streaming
+
+| Component | Description |
+|-----------|-------------|
+| **[AT](query-at)** | Query data at a specific point in time |
+| **[CHANGES](changes)** | Track insertions, updates, and deletions |
+| **[WITH CONSUME](with-consume)** | Process streaming data with offset management |
+| **[WITH STREAM HINTS](with-stream-hints)** | Optimize stream processing behavior |
+
+## Query Execution
+
+| Component | Description |
+|-----------|-------------|
+| **[Settings](settings)** | Configure query optimization and execution parameters |
+
+## Query Structure
+
+A typical Databend query follows this structure:
+
+```sql
+[WITH cte_expressions]
+SELECT [TOP n] columns
+FROM table
+[JOIN other_tables]
+[WHERE conditions]
+[GROUP BY columns]
+[HAVING group_conditions]
+[QUALIFY window_conditions]
+[ORDER BY columns]
+[LIMIT n]
+```

--- a/docs/en/sql-reference/10-sql-commands/20-query-syntax/with-clause.md
+++ b/docs/en/sql-reference/10-sql-commands/20-query-syntax/with-clause.md
@@ -2,4 +2,103 @@
 title: WITH Clause
 ---
 
-Databend uses the WITH clause for common table expressions (CTEs).
+The WITH clause is an optional clause that precedes the body of the SELECT statement, and defines one or more CTEs (common table expressions) that can be referenced later in the statement.
+
+
+## Syntax
+
+### Basic CTE
+
+```sql
+[ WITH
+    cte_name1 [ ( cte_column_list ) ] AS ( SELECT ... )
+  [ , cte_name2 [ ( cte_column_list ) ] AS ( SELECT ... ) ]
+  [ , cte_nameN [ ( cte_column_list ) ] AS ( SELECT ... ) ]
+]
+SELECT ...
+```
+
+### Recursive CTE
+
+```sql
+[ WITH [ RECURSIVE ]
+    cte_name1 ( cte_column_list ) AS ( anchorClause UNION ALL recursiveClause )
+  [ , cte_name2 ( cte_column_list ) AS ( anchorClause UNION ALL recursiveClause ) ]
+  [ , cte_nameN ( cte_column_list ) AS ( anchorClause UNION ALL recursiveClause ) ]
+]
+SELECT ...
+```
+
+Where:
+- `anchorClause`: `SELECT anchor_column_list FROM ...`
+- `recursiveClause`: `SELECT recursive_column_list FROM ... [ JOIN ... ]`
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `cte_name` | The CTE name must follow standard identifier rules |
+| `cte_column_list` | The names of the columns in the CTE |
+| `anchor_column_list` | The columns used in the anchor clause for the recursive CTE |
+| `recursive_column_list` | The columns used in the recursive clause for the recursive CTE |
+
+## Examples
+
+### Basic CTE
+
+```sql
+WITH high_value_customers AS (
+    SELECT customer_id, customer_name, total_spent
+    FROM customers 
+    WHERE total_spent > 10000
+)
+SELECT c.customer_name, o.order_date, o.order_amount
+FROM high_value_customers c
+JOIN orders o ON c.customer_id = o.customer_id
+ORDER BY o.order_date DESC;
+```
+
+### Multiple CTEs
+
+```sql
+WITH
+  regional_sales AS (
+    SELECT region, SUM(sales_amount) as total_sales
+    FROM sales_data
+    GROUP BY region
+  ),
+  top_regions AS (
+    SELECT region, total_sales
+    FROM regional_sales
+    WHERE total_sales > 1000000
+  )
+SELECT r.region, r.total_sales
+FROM top_regions r
+ORDER BY r.total_sales DESC;
+```
+
+### Recursive CTE
+
+```sql
+WITH RECURSIVE countdown AS (
+    -- Anchor clause: starting point
+    SELECT 10 as num
+    
+    UNION ALL
+    
+    -- Recursive clause: repeat until condition
+    SELECT num - 1
+    FROM countdown 
+    WHERE num > 1  -- Stop condition
+)
+SELECT num FROM countdown 
+ORDER BY num DESC;
+```
+
+## Usage Notes
+
+- CTEs are temporary named result sets that exist only for the duration of the query
+- CTE names must be unique within the same WITH clause
+- A CTE can reference previously defined CTEs in the same WITH clause
+- Recursive CTEs require both an anchor clause and a recursive clause connected by UNION ALL
+- The RECURSIVE keyword is required when using recursive CTEs

--- a/docs/en/sql-reference/10-sql-commands/30-query-operators/index.md
+++ b/docs/en/sql-reference/10-sql-commands/30-query-operators/index.md
@@ -1,8 +1,16 @@
 ---
 title: Query Operators
 ---
-import IndexOverviewList from '@site/src/components/IndexOverviewList';
 
 This page provides reference information for the query operators in Databend.
 
-<IndexOverviewList />
+## Operator Types
+
+| Operator Type | Description |
+|--------------|-------------|
+| **[Arithmetic](arithmetic)** | Mathematical operations (+, -, *, /, %, DIV) |
+| **[Comparison](comparison)** | Value comparisons (=, !=, &lt;, &gt;, &lt;=, &gt;=, BETWEEN, IN) |
+| **[Logical](logical)** | Boolean logic (AND, OR, NOT, XOR) |
+| **[JSON](json)** | JSON data operations (::, -&gt;, -&gt;&gt;, @&gt;, &lt;@) |
+| **[Set](set)** | Combine query results (UNION, INTERSECT, EXCEPT) |
+| **[Subquery](subquery)** | Nested queries (EXISTS, IN, ANY, ALL, SOME) |

--- a/docs/en/sql-reference/10-sql-commands/50-administration-cmds/index.md
+++ b/docs/en/sql-reference/10-sql-commands/50-administration-cmds/index.md
@@ -1,8 +1,46 @@
 ---
 title: Administration Commands
 ---
-import IndexOverviewList from '@site/src/components/IndexOverviewList';
 
 This page provides reference information for the system administration commands in Databend.
 
-<IndexOverviewList />
+## System Monitoring
+
+| Command | Description |
+|---------|-------------|
+| **[SHOW PROCESSLIST](07-show-processlist)** | Display active queries and connections |
+| **[SHOW METRICS](08-show-metrics)** | View system performance metrics |
+| **[KILL](01-kill)** | Terminate running queries or connections |
+| **[RUST BACKTRACE](rust-backtrace)** | Debug Rust stack traces |
+
+## Configuration Management
+
+| Command | Description |
+|---------|-------------|
+| **[SET](02-set-global)** | Set global configuration parameters |
+| **[UNSET](02-unset)** | Remove configuration settings |
+| **[SET VARIABLE](03-set-var)** | Manage user-defined variables |
+| **[SHOW SETTINGS](03-show-settings)** | Display current system settings |
+
+## Function Management
+
+| Command | Description |
+|---------|-------------|
+| **[SHOW FUNCTIONS](04-show-functions)** | List built-in functions |
+| **[SHOW USER FUNCTIONS](05-show-user-functions)** | List user-defined functions |
+| **[SHOW TABLE FUNCTIONS](06-show-table-functions)** | List table-valued functions |
+
+## Storage Maintenance
+
+| Command | Description |
+|---------|-------------|
+| **[VACUUM TABLE](09-vacuum-table)** | Reclaim storage space from tables |
+| **[VACUUM DROP TABLE](09-vacuum-drop-table)** | Clean up dropped table data |
+| **[VACUUM TEMP FILES](09-vacuum-temp-files)** | Remove temporary files |
+| **[SHOW INDEXES](show-indexes)** | Display table indexes |
+
+## Dynamic Execution
+
+| Command | Description |
+|---------|-------------|
+| **[EXECUTE IMMEDIATE](execute-immediate)** | Execute dynamically constructed SQL statements |

--- a/docs/en/sql-reference/10-sql-commands/index.md
+++ b/docs/en/sql-reference/10-sql-commands/index.md
@@ -2,30 +2,15 @@
 title: SQL Commands Reference
 ---
 
-These topics provide reference information for various SQL commands.
+These topics provide reference information for various SQL commands in Databend.
 
-## SQL Commands
+## Command Categories
 
-### DDL Commands
-- Overview and documentation of Data Definition Language (DDL) commands.
-  [Read More](./00-ddl/index.md)
-
-### DML Commands
-- Information on Data Manipulation Language (DML) commands for handling data.
-  [Read More](./10-dml/index.md)
-
-### Query Syntax
-- Detailed guide on SQL query syntax, including various clauses and usage.
-  [Read More](./20-query-syntax/index.md)
-
-### Query Operators
-- Descriptions of SQL query operators, including logical, comparison, and others.
-  [Read More](./30-query-operators/index.md)
-
-### Administration Commands
-- Commands for database administration, settings, and performance monitoring.
-  [Read More](50-administration-cmds/index.md)
-
-### Explain Commands
-- Documentation on 'EXPLAIN' commands used for query analysis and optimization.
-  [Read More](40-explain-cmds/index.md)
+| Category | Description |
+|----------|-------------|
+| **[DDL Commands](00-ddl/index.md)** | Data Definition Language - Create, alter, and drop database objects |
+| **[DML Commands](10-dml/index.md)** | Data Manipulation Language - Insert, update, delete, and copy data |
+| **[Query Syntax](20-query-syntax/index.md)** | SELECT statement components - FROM, WHERE, GROUP BY, JOIN, etc. |
+| **[Query Operators](30-query-operators/index.md)** | Arithmetic, comparison, logical, and other operators |
+| **[EXPLAIN Commands](40-explain-cmds/index.md)** | Query analysis and optimization tools |
+| **[Administration Commands](50-administration-cmds/index.md)** | System monitoring, configuration, and maintenance |


### PR DESCRIPTION
- Restored lost WITH clause documentation with syntax, examples, and usage notes
- Improved SQL reference index pages with clean 2-column table format
- Fixed MDX compilation error by escaping angle brackets in operators
- Organized content into logical categories for better navigation