### PR TITLE
Fix: Replace unsupported MATERIALIZED VIEW with AGGREGATING INDEX

### DIFF
--- a/docs/en/guides/54-query/03-optimization/index.md
+++ b/docs/en/guides/54-query/03-optimization/index.md
@@ -171,10 +171,10 @@ LIMIT 10;
 
 ## Advanced Optimization
 
-### Materialized Views
+### Aggregating Indexes
 ```sql
--- Pre-compute expensive aggregations
-CREATE MATERIALIZED VIEW daily_sales AS
+-- Pre-compute expensive aggregations using Databend's aggregating indexes
+CREATE AGGREGATING INDEX daily_sales_agg AS
 SELECT 
     DATE(order_time) as order_date,
     product_id,


### PR DESCRIPTION
## Summary

Replace incorrect MATERIALIZED VIEW syntax with AGGREGATING INDEX in query optimization documentation.

## Changes Made

- Updated Advanced Optimization section to use  instead of 
- Corrected syntax to reflect Databend's actual capabilities
- Verified the new syntax works correctly in production

## Rationale

Databend does not support  syntax. The documentation was misleading users to try unsupported features.  provides similar functionality for pre-computing expensive aggregations.

## Testing

- [x] Verified  syntax works in Databend
- [x] Confirmed  is not supported
- [x] Documentation accurately reflects supported functionality