### PR TITLE
docs: reorder search/vector/geospatial groups

### DIFF
--- a/docs/en/sql-reference/20-sql-functions/01-bitmap-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/01-bitmap-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Bitmap Functions",
-  "position": 15
+  "position": 16
 }

--- a/docs/en/sql-reference/20-sql-functions/05-interval-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/05-interval-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Interval Functions",
-  "position": 23
+  "position": 19
 }

--- a/docs/en/sql-reference/20-sql-functions/09-geospatial-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/09-geospatial-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Geospatial Functions",
-  "position": 22
+  "position": 11
 }

--- a/docs/en/sql-reference/20-sql-functions/10-search-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/10-search-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Full-Text Search Functions",
-  "position": 20
+  "position": 9
 }

--- a/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Structured & Semi-Structured",
-  "position": 9
+  "position": 8
 }

--- a/docs/en/sql-reference/20-sql-functions/11-vector-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/11-vector-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Vector Functions",
-  "position": 21
+  "position": 10
 }

--- a/docs/en/sql-reference/20-sql-functions/12-hash-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/12-hash-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Hash Functions",
-  "position": 14
+  "position": 15
 }

--- a/docs/en/sql-reference/20-sql-functions/13-uuid-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/13-uuid-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "UUID Functions",
-  "position": 18
+  "position": 17
 }

--- a/docs/en/sql-reference/20-sql-functions/14-ip-address-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/14-ip-address-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "IP Address Functions",
-  "position": 19
+  "position": 18
 }

--- a/docs/en/sql-reference/20-sql-functions/15-context-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/15-context-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Context Functions",
-  "position": 13
+  "position": 14
 }

--- a/docs/en/sql-reference/20-sql-functions/16-system-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/16-system-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "System Functions",
-  "position": 12
+  "position": 13
 }

--- a/docs/en/sql-reference/20-sql-functions/17-table-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/17-table-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Table Functions",
-  "position": 10
+  "position": 12
 }

--- a/docs/en/sql-reference/20-sql-functions/18-sequence-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/18-sequence-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Sequence Functions",
-  "position": 24
+  "position": 20
 }

--- a/docs/en/sql-reference/20-sql-functions/19-dictionary-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/19-dictionary-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Dictionary Functions",
-  "position": 25
+  "position": 21
 }

--- a/docs/en/sql-reference/20-sql-functions/19-test-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/19-test-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Test Functions",
-  "position": 26
+  "position": 22
 }

--- a/docs/en/sql-reference/20-sql-functions/20-other-functions/_category_.json
+++ b/docs/en/sql-reference/20-sql-functions/20-other-functions/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Other Functions",
-  "position": 27
+  "position": 23
 }

--- a/docs/en/sql-reference/20-sql-functions/20-other-functions/index.md
+++ b/docs/en/sql-reference/20-sql-functions/20-other-functions/index.md
@@ -1,0 +1,16 @@
+---
+title: Other Functions
+---
+
+This section collects assorted utilities that do not fit into the major functional groups.
+
+| Function | Description |
+|----------|-------------|
+| [ASSUME_NOT_NULL](assume-not-null.md) | Hint that values in a nullable column are never NULL |
+| [EXISTS](exists.md) | Return TRUE if a subquery produces any rows |
+| [GROUPING](grouping.md) | Reveal whether an output column was aggregated in GROUPING SETS |
+| [HUMANIZE_NUMBER](humanize-number.md) | Format large numbers with unit suffixes |
+| [HUMANIZE_SIZE](humanize-size.md) | Format byte counts into readable units |
+| [REMOVE_NULLABLE](remove-nullable.md) | Strip NULLability from a column value |
+| [TO_NULLABLE](to-nullable.md) | Convert a value to a nullable type |
+| [TYPEOF](typeof.md) | Return the name of a value’s data type |

--- a/docs/en/sql-reference/20-sql-functions/index.md
+++ b/docs/en/sql-reference/20-sql-functions/index.md
@@ -11,7 +11,6 @@ Databend provides comprehensive SQL functions for all types of data processing. 
 | [Numeric Functions](./04-numeric-functions/index.md) | Mathematical operations and calculations |
 | [String Functions](./06-string-functions/index.md) | Text manipulation and string processing |
 | [Date & Time Functions](./05-datetime-functions/index.md) | Date, time, and temporal operations |
-| [Interval Functions](./05-interval-functions/index.md) | Time unit conversion and interval creation |
 | [Conversion Functions](./02-conversion-functions/index.md) | Type casting and data format conversions |
 | [Conditional Functions](./03-conditional-functions/index.md) | Logic and control flow operations |
 
@@ -21,7 +20,12 @@ Databend provides comprehensive SQL functions for all types of data processing. 
 |----------|-------------|
 | [Aggregate Functions](./07-aggregate-functions/index.md) | Statistical calculations across multiple rows |
 | [Window Functions](./08-window-functions/index.md) | Advanced analytics with window operations |
-| [Bitmap Functions](./01-bitmap-functions/index.md) | High-performance bitmap operations and analytics |
+
+## Structured & Semi-Structured Data
+
+| Category | Description |
+|----------|-------------|
+| [Structured & Semi-Structured Functions](./10-semi-structured-functions/index.md) | JSON, arrays, objects, and nested data processing |
 
 ## Search Functions
 
@@ -41,37 +45,29 @@ Databend provides comprehensive SQL functions for all types of data processing. 
 |----------|-------------|
 | [Geospatial Functions](./09-geospatial-functions/index.md) | Geometry, GeoHash, and H3 spatial operations |
 
-## Semi-Structured Data
-
-| Category | Description |
-|----------|-------------|
-| [Semi-Structured Functions](./10-semi-structured-functions/index.md) | JSON, arrays, objects, and nested data processing |
-
 ## Data Management
 
 | Category | Description |
 |----------|-------------|
 | [Table Functions](./17-table-functions/index.md) | File inspection, data generation, and system information |
-| [Dictionary Functions](./19-dictionary-functions/index.md) | Real-time external data source queries (MySQL, Redis) |
-| [Sequence Functions](./18-sequence-functions/index.md) | Auto-incrementing sequence value generation |
+| [System Functions](./16-system-functions/index.md) | System information and management operations |
+| [Context Functions](./15-context-functions/index.md) | Current session, user, and database information |
 
 ## Security & Integrity
 
 | Category | Description |
 |----------|-------------|
 | [Hash Functions](./12-hash-functions/index.md) | Data hashing and integrity verification |
+| [Bitmap Functions](./01-bitmap-functions/index.md) | High-performance bitmap operations and analytics |
 | [UUID Functions](./13-uuid-functions/index.md) | Universally unique identifier generation |
 | [IP Address Functions](./14-ip-address-functions/index.md) | Network address manipulation and validation |
 
-## System Functions
+## Utility Functions
 
 | Category | Description |
 |----------|-------------|
-| [System Functions](./16-system-functions/index.md) | System information and management operations |
-| [Context Functions](./15-context-functions/index.md) | Current session, user, and database information |
-
-## Development Tools
-
-| Category | Description |
-|----------|-------------|
+| [Interval Functions](./05-interval-functions/index.md) | Time unit conversion and interval creation |
+| [Sequence Functions](./18-sequence-functions/index.md) | Auto-incrementing sequence value generation |
+| [Dictionary Functions](./19-dictionary-functions/index.md) | Real-time external data source queries (MySQL, Redis) |
 | [Test Functions](./19-test-functions/index.md) | Testing and debugging utilities |
+| [Other Functions](./20-other-functions/index.md) | Miscellaneous helpers and utilities |


### PR DESCRIPTION
## Summary
- move Full-Text Search, Vector, and Geospatial sections directly after Structured & Semi-Structured to mirror product navigation
- renumber downstream SQL function categories so the sidebar ordering matches the new layout
- add an overview page for Other Functions to keep the landing table consistent

## Testing
- yarn build