### PR TITLE
Polish manual PR translation workflow

### DIFF
--- a/.github/workflows/docs-pr.translate.yaml
+++ b/.github/workflows/docs-pr.translate.yaml
@@ -190,7 +190,6 @@ jobs:
           SOURCE_PR: ${{ steps.pr.outputs.pr_number }}
           SOURCE_PR_URL: ${{ steps.pr.outputs.html_url }}
           REMOVED_FILES: ${{ steps.collect.outputs.removed_cn }}
-          TRANSLATION_BRANCH: ${{ steps.branch.outputs.branch }}
         with:
           script: |
             const branch = '${{ steps.branch.outputs.branch }}';


### PR DESCRIPTION
## Summary
- remove duplicate translation-branch cleanup (deletions + .translation-init removal) into a single finalize step
- keep translation branches aligned to main while annotating source PR info

## Testing
- gh workflow run "GPT Translate by PR" --ref feature/ci-translate-pr-v2 -f pr=https://github.com/databendlabs/databend-docs/pull/2877