### PR TITLE
Fix CN geospatial doc links

### DIFF
--- a/docs/cn/sql-reference/00-sql-reference/10-data-types/geospatial.md
+++ b/docs/cn/sql-reference/00-sql-reference/10-data-types/geospatial.md
@@ -50,8 +50,7 @@ SET geometry_output_format = 'geojson';
 
 浏览以下链接，了解按类别组织的所有可用地理空间函数。
 
-- [Geometry Functions](../../20-sql-functions/09-geometry-functions/index.md)
-- [H3](../../20-sql-functions/09-geo-functions/index.md)
+- [地理空间函数](../../20-sql-functions/09-geospatial-functions/index.md)
 
 ## 示例
 


### PR DESCRIPTION
## Summary
- point the geospatial data types page to the existing geospatial functions overview
- remove stale links to non-existent 09-geometry-functions and 09-geo-functions directories

## Testing
- not run