### PR TITLE
Fix CN guides and lambda doc links

### DIFF
--- a/docs/cn/guides/00-products/index.md
+++ b/docs/cn/guides/00-products/index.md
@@ -34,4 +34,4 @@ Databend 是新一代多模态 Data+AI 数仓，原生列式存储覆盖结构�
 **性能与扩展**
 - **[性能优化](/guides/performance)**: 通过各种策略提升查询性能。
 - **[基准测试](/guides/benchmark)**: 将 Databend 的性能与其他数据仓库（Data Warehouse）进行比较。
-- **[数据湖仓](/guides/access-data-lake)**: 与 Hive、Iceberg 和 Delta Lake 无缝集成。
+- **[数据湖仓](/sql/sql-reference/table-engines)**: 与 Hive、Iceberg 和 Delta Lake 无缝集成。

--- a/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
+++ b/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
@@ -6,7 +6,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="引入或更新版本：v1.2.762"/>
 
-使用指定的转换 Lambda 表达式（Lambda Expression）转换 JSON 数组的每个元素。有关 Lambda 表达式的更多信息，请参阅 [Lambda 表达式](/cn/sql/stored-procedure-scripting/#lambda-expressions)。
+使用指定的转换 Lambda 表达式（Lambda Expression）转换 JSON 数组的每个元素。有关 Lambda 表达式的更多信息，请参阅 [Lambda 表达式](/sql/sql-reference/stored-procedure-scripting/#lambda-表达式)。
 
 ## 语法
 

--- a/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
+++ b/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
@@ -5,7 +5,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="引入或更新版本：v1.2.762"/>
 
-根据指定条件过滤 JSON 对象中的键值对，条件使用 [Lambda 表达式](/cn/sql/stored-procedure-scripting/#lambda-expressions)定义。
+根据指定条件过滤 JSON 对象中的键值对，条件使用 [Lambda 表达式](/sql/sql-reference/stored-procedure-scripting/#lambda-表达式)定义。
 
 ## 语法
 


### PR DESCRIPTION
## Summary
- update the product overview to link to the table engine docs instead of a removed access-data-lake page
- point lambda expression references to the current stored procedure doc path

## Testing
- not run