### PR TITLE
Fix CN doc link regressions

### DIFF
--- a/docs/cn/guides/00-products/index.md
+++ b/docs/cn/guides/00-products/index.md
@@ -34,4 +34,4 @@ Databend 是新一代多模态 Data+AI 数仓，原生列式存储覆盖结构�
 **性能与扩展**
 - **[性能优化](/guides/performance)**: 通过各种策略提升查询性能。
 - **[基准测试](/guides/benchmark)**: 将 Databend 的性能与其他数据仓库（Data Warehouse）进行比较。
-- **[数据湖仓](/guides/access-data-lake)**: 与 Hive、Iceberg 和 Delta Lake 无缝集成。
+- **[数据湖仓](/sql/sql-reference/table-engines)**: 与 Hive、Iceberg 和 Delta Lake 无缝集成。

--- a/docs/cn/sql-reference/00-sql-reference/10-data-types/geospatial.md
+++ b/docs/cn/sql-reference/00-sql-reference/10-data-types/geospatial.md
@@ -50,8 +50,7 @@ SET geometry_output_format = 'geojson';
 
 浏览以下链接，了解按类别组织的所有可用地理空间函数。
 
-- [Geometry Functions](../../20-sql-functions/09-geometry-functions/index.md)
-- [H3](../../20-sql-functions/09-geo-functions/index.md)
+- [地理空间函数](../../20-sql-functions/09-geospatial-functions/index.md)
 
 ## 示例
 

--- a/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
+++ b/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
@@ -6,7 +6,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="引入或更新版本：v1.2.762"/>
 
-使用指定的转换 Lambda 表达式（Lambda Expression）转换 JSON 数组的每个元素。有关 Lambda 表达式的更多信息，请参阅 [Lambda 表达式](/cn/sql/stored-procedure-scripting/#lambda-expressions)。
+使用指定的转换 Lambda 表达式（Lambda Expression）转换 JSON 数组的每个元素。有关 Lambda 表达式的更多信息，请参阅 [Lambda 表达式](../../../30-stored-procedure-scripting/index.md#lambda-表达式)。
 
 ## 语法
 

--- a/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
+++ b/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
@@ -5,7 +5,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="引入或更新版本：v1.2.762"/>
 
-根据指定条件过滤 JSON 对象中的键值对，条件使用 [Lambda 表达式](/cn/sql/stored-procedure-scripting/#lambda-expressions)定义。
+根据指定条件过滤 JSON 对象中的键值对，条件使用 [Lambda 表达式](../../../30-stored-procedure-scripting/index.md#lambda-表达式)定义。
 
 ## 语法
 

--- a/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
+++ b/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
@@ -6,7 +6,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="Introduced or updated: v1.2.762"/>
 
-Transforms each element of a JSON array using a specified transformation Lambda expression. For more information about Lambda expression, see [Lambda Expressions](/sql/stored-procedure-scripting/#lambda-expressions).
+Transforms each element of a JSON array using a specified transformation Lambda expression. For more information about Lambda expression, see [Lambda Expressions](../../../30-stored-procedure-scripting/index.md#lambda-expressions).
 
 ## Syntax
 

--- a/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
+++ b/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
@@ -5,7 +5,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="Introduced or updated: v1.2.762"/>
 
-Filters key-value pairs in a JSON object based on a specified condition, defined using a [lambda expression](/sql/stored-procedure-scripting/#lambda-expressions).
+Filters key-value pairs in a JSON object based on a specified condition, defined using a [lambda expression](../../../30-stored-procedure-scripting/index.md#lambda-expressions).
 
 ## Syntax
 


### PR DESCRIPTION
## Summary
- remove stale geometry/H3 links from cn geospatial data type doc and point to existing geospatial overview
- update array/map lambda references (cn/en) to correct stored procedure path

## Testing
- npm run build:cn