### PR TITLE
Fix lambda expression links in CN/EN docs

### DIFF
--- a/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
+++ b/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
@@ -6,7 +6,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="引入或更新版本：v1.2.762"/>
 
-使用指定的转换 Lambda 表达式（Lambda Expression）转换 JSON 数组的每个元素。有关 Lambda 表达式的更多信息，请参阅 [Lambda 表达式](/sql/sql-reference/stored-procedure-scripting/#lambda-表达式)。
+使用指定的转换 Lambda 表达式（Lambda Expression）转换 JSON 数组的每个元素。有关 Lambda 表达式的更多信息，请参阅 [Lambda 表达式](../../../30-stored-procedure-scripting/index.md#lambda-表达式)。
 
 ## 语法
 

--- a/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
+++ b/docs/cn/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
@@ -5,7 +5,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="引入或更新版本：v1.2.762"/>
 
-根据指定条件过滤 JSON 对象中的键值对，条件使用 [Lambda 表达式](/sql/sql-reference/stored-procedure-scripting/#lambda-表达式)定义。
+根据指定条件过滤 JSON 对象中的键值对，条件使用 [Lambda 表达式](../../../30-stored-procedure-scripting/index.md#lambda-表达式)定义。
 
 ## 语法
 

--- a/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
+++ b/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/1-array/array-transform.md
@@ -6,7 +6,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="Introduced or updated: v1.2.762"/>
 
-Transforms each element of a JSON array using a specified transformation Lambda expression. For more information about Lambda expression, see [Lambda Expressions](/sql/stored-procedure-scripting/#lambda-expressions).
+Transforms each element of a JSON array using a specified transformation Lambda expression. For more information about Lambda expression, see [Lambda Expressions](../../../30-stored-procedure-scripting/index.md#lambda-expressions).
 
 ## Syntax
 

--- a/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
+++ b/docs/en/sql-reference/20-sql-functions/10-semi-structured-functions/3-map/map-filter.md
@@ -5,7 +5,7 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 <FunctionDescription description="Introduced or updated: v1.2.762"/>
 
-Filters key-value pairs in a JSON object based on a specified condition, defined using a [lambda expression](/sql/stored-procedure-scripting/#lambda-expressions).
+Filters key-value pairs in a JSON object based on a specified condition, defined using a [lambda expression](../../../30-stored-procedure-scripting/index.md#lambda-expressions).
 
 ## Syntax
 


### PR DESCRIPTION
## Summary
- update cn/en array-transform and map-filter docs so lambda links point to the current stored procedure page using relative paths

## Testing
- npm run build:cn