### PR TITLE
fix: add missing slug to CN quickstart page

### DIFF
--- a/docs/cn/guides/10-deploy/00-QuickStart/index.md
+++ b/docs/cn/guides/10-deploy/00-QuickStart/index.md
@@ -1,5 +1,6 @@
 ---
 title: 快速入门
+slug: /deploy/quickstart
 ---
 
 Databend 快速入门：5 分钟体验 Databend


### PR DESCRIPTION
## Problem

CN build was failing with broken links:
```
- Broken link on source page path = /guides/:
   -> linking to /guides/deploy/quickstart/
   -> linking to /guides/deploy/quickstart
- Broken link on source page path = /guides/products/dce:
   -> linking to /guides/deploy/quickstart/
```

## Solution

Added `slug: /deploy/quickstart` to CN quickstart page frontmatter to match the EN version.

## Related
- Fixes CI failure in main branch after #2905 was merged
- Related to PR #2905