### PR TITLE
Fix CityDrive JSON join to use frame_metadata_catalog

### DIFF
--- a/docs/cn/guides/54-query/00-sql-analytics.md
+++ b/docs/cn/guides/54-query/00-sql-analytics.md
@@ -101,8 +101,8 @@ SELECT f.frame_id,
        obj.value['type']::STRING AS detected_type,
        obj.value['confidence']::DOUBLE AS confidence
 FROM frame_events AS f
-JOIN frame_payloads AS p ON f.frame_id = p.frame_id,
-     LATERAL FLATTEN(input => p.payload['objects']) AS obj
+JOIN frame_metadata_catalog AS meta ON meta.doc_id = f.frame_id,
+     LATERAL FLATTEN(input => meta.meta_json['detections']['objects']) AS obj
 WHERE f.event_tag = 'pedestrian'
 ORDER BY confidence DESC;
 ```

--- a/docs/cn/guides/54-query/02-vector-db.md
+++ b/docs/cn/guides/54-query/02-vector-db.md
@@ -4,7 +4,7 @@ title: 向量搜索
 
 > **场景：** CityDrive 把每个帧的嵌入直接存放在 Databend,语义相似搜索（“找出和它看起来像的帧”）便可与传统 SQL 分析一同运行,无需再部署独立的向量服务。
 
-`frame_embeddings` 表与 `frame_events`、`frame_payloads`、`frame_geo_points` 共用同一批 `frame_id`,让语义检索与常规 SQL 牢牢绑定在一起。
+`frame_embeddings` 表与 `frame_events`、`frame_metadata_catalog`、`frame_geo_points` 共用同一批 `frame_id`,让语义检索与常规 SQL 牢牢绑定在一起。
 
 ## 1. 准备嵌入表
 生产模型通常输出 512–1536 维,本例使用 512 维方便直接复制到演示集群。

--- a/docs/en/guides/54-query/00-sql-analytics.md
+++ b/docs/en/guides/54-query/00-sql-analytics.md
@@ -101,8 +101,8 @@ SELECT f.frame_id,
        obj.value['type']::STRING AS detected_type,
        obj.value['confidence']::DOUBLE AS confidence
 FROM frame_events AS f
-JOIN frame_payloads AS p ON f.frame_id = p.frame_id,
-     LATERAL FLATTEN(input => p.payload['objects']) AS obj
+JOIN frame_metadata_catalog AS meta ON meta.doc_id = f.frame_id,
+     LATERAL FLATTEN(input => meta.meta_json['detections']['objects']) AS obj
 WHERE f.event_tag = 'pedestrian'
 ORDER BY confidence DESC;
 ```

--- a/docs/en/guides/54-query/02-vector-db.md
+++ b/docs/en/guides/54-query/02-vector-db.md
@@ -4,7 +4,7 @@ title: Vector Search
 
 > **Scenario:** CityDrive keeps per-frame embeddings in Databend so semantic similarity search (“find frames that look like this”) runs alongside traditional SQL analytics—no extra vector service required.
 
-The `frame_embeddings` table shares the same `frame_id` keys as `frame_events`, `frame_payloads`, and `frame_geo_points`, which keeps semantic search and classic SQL glued together.
+The `frame_embeddings` table shares the same `frame_id` keys as `frame_events`, `frame_metadata_catalog`, and `frame_geo_points`, which keeps semantic search and classic SQL glued together.
 
 ## 1. Prepare the Embedding Table
 Production models tend to emit 512–1536 dimensions. The example below uses 512 so you can copy it straight into a demo cluster without changing the DDL.


### PR DESCRIPTION
## Summary
- fix the LATERAL FLATTEN example to join frame_metadata_catalog and unnest detections
- align English and Chinese vector intros to mention frame_metadata_catalog instead of frame_payloads

## Testing
- not run (docs change)