### PR TITLE
docs: update masking policy privileges

### DIFF
--- a/docs/cn/guides/56-security/access-control/01-privileges.md
+++ b/docs/cn/guides/56-security/access-control/01-privileges.md
@@ -108,15 +108,17 @@ Databend 提供多种权限，实现对数据库对象的细粒度控制，可�
 ### 所有权限
 
 | 权限              | 对象类型                      | 描述                                                                                                                                        |
-|:------------------|:------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|
-| ALL               | 所有                          | 授予指定对象类型的全部权限。                                                                                                                       |
-| ALTER             | Global, Database, Table, View | 修改数据库、表、用户或 UDF。                                                                                                                       |
-| CREATE            | Global, Table                 | 创建表或 UDF。                                                                                                                                     |
-| CREATE DATABASE   | Global                        | 创建数据库或 UDF。                                                                                                                                 |
-| CREATE WAREHOUSE  | Global                        | 创建 Warehouse。                                                                                                                                   |
-| CREATE CONNECTION | Global                        | 创建 Connection。                                                                                                                                  |
-| CREATE SEQUENCE   | Global                        | 创建 Sequence。                                                                                                                                    |
-| CREATE PROCEDURE  | PROCEDURE                     | 创建 Procedure。                                                                                                                                   |
+|:------------------|:------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------|
+| ALL               | 所有                          | 授予指定对象类型的全部权限。                                                                                                                |
+| APPLY MASKING POLICY | Global, Masking Policy     | 附加/解除、描述或删除脱敏策略。授予 `*.*` 时，可在整个账号范围管理所有脱敏策略。                                                           |
+| ALTER             | Global, Database, Table, View | 修改数据库、表、用户或 UDF。                                                                                                                |
+| CREATE            | Global, Table                 | 创建表或 UDF。                                                                                                                              |
+| CREATE DATABASE   | Global                        | 创建数据库或 UDF。                                                                                                                          |
+| CREATE WAREHOUSE  | Global                        | 创建 Warehouse。                                                                                                                            |
+| CREATE CONNECTION | Global                        | 创建 Connection。                                                                                                                           |
+| CREATE SEQUENCE   | Global                        | 创建 Sequence。                                                                                                                             |
+| CREATE PROCEDURE  | PROCEDURE                     | 创建 Procedure。                                                                                                                            |
+| CREATE MASKING POLICY | Global                    | 创建脱敏策略。                                                                                                                              |
 | DELETE            | Table                         | 删除或截断表中的行。                                                                                                                               |
 | DROP              | Global, Database, Table, View | 删除数据库、表、View 或 UDF；恢复已删除的表。                                                                                                      |
 | INSERT            | Table                         | 向表插入行。                                                                                                                                       |
@@ -257,3 +259,12 @@ Databend 提供多种权限，实现对数据库对象的细粒度控制，可�
 | Access Procedure | 可访问 Procedure（如 Drop、Call、Desc）。                                             |
 | ALL              | 授予指定对象类型的 Access Procedure 权限。                                            |
 | OWNERSHIP        | 授予对 Procedure 的完全控制权；在特定对象上一次只能有一个角色持有此权限。             |
+
+### 脱敏策略权限
+
+除 `CREATE MASKING POLICY` 与 `APPLY MASKING POLICY` 全局权限外，还可以针对单个脱敏策略授予权限：
+
+| 权限  | 描述                                                                                                   |
+|:------|:--------------------------------------------------------------------------------------------------------|
+| APPLY | 将脱敏策略绑定/解绑到列，同时允许执行 DESC/DROP 操作。                                                  |
+| OWNERSHIP | 授予对脱敏策略的完全控制权。Databend 会在策略创建时自动将 OWNERSHIP 授予当前角色，并在策略被删除时自动回收。 |

--- a/docs/cn/guides/56-security/masking-policy.md
+++ b/docs/cn/guides/56-security/masking-policy.md
@@ -81,6 +81,12 @@ SELECT * FROM user_info;
 - 确保用户已分配适当角色
 - 角色管理请参考 [User & Role](/sql/sql-commands/ddl/user/)
 
+### 所需权限
+
+- 需要将 `CREATE MASKING POLICY`（通常授予 `*.*`）赋予负责创建或替换脱敏策略的角色。Databend 会在策略创建完成后自动将该策略的 OWNERSHIP 授予当前角色。
+- 需要将全局 `APPLY MASKING POLICY` 权限，或使用 `GRANT APPLY ON MASKING POLICY <policy_name>` 为角色授予特定策略的控制权，才能在 `ALTER TABLE` 中设置/解除策略；拥有该策略的 OWNERSHIP 也可执行这些操作。
+- 通过 `SHOW GRANTS ON MASKING POLICY <policy_name>` 可以审计哪些角色拥有 APPLY 或 OWNERSHIP 权限。
+
 ## 策略管理
 
 有关创建、修改和管理动态脱敏策略（Masking Policy）的详细命令，请查阅：

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/01-table/90-alter-table.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/01-table/90-alter-table.md
@@ -6,7 +6,7 @@ slug: /sql-commands/ddl/table/alter-table
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="引入或更新于：v1.2.821"/>
+<FunctionDescription description="引入或更新于：v1.2.845"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -75,6 +75,7 @@ DROP [ COLUMN ] <column_name>
 - 当声明了 `USING (...)` 时，必须至少提供被脱敏的列以及策略所需的其他列，并确保 `USING` 中的第一个标识符与正在修改的列一致。
 - 只有常规表支持绑定脱敏策略；视图、流表以及临时表均无法执行 `SET MASKING POLICY`。
 - 单个列最多只能附加一个安全策略（无论是列脱敏还是行级策略）。在重新绑定之前，请先移除原有策略。
+- 设置或取消设置脱敏策略需要拥有全局 `APPLY MASKING POLICY` 权限，或针对目标策略具有 APPLY/OWNERSHIP 权限，否则 `ALTER TABLE` 会被拒绝。
 :::
 
 :::caution

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/02-user/11-revoke.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/02-user/11-revoke.md
@@ -4,7 +4,7 @@ sidebar_position: 11
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.275"/>
+<FunctionDescription description="Introduced or updated: v1.2.845"/>
 
 撤销特定数据库对象的权限、角色和所有权。 这包括：
 
@@ -48,6 +48,9 @@ schemaObjectPrivileges ::=
 
 -- For UDF
   { USAGE }
+
+-- For MASKING POLICY
+  { CREATE MASKING POLICY | APPLY MASKING POLICY }
 ```
 
 ```sql
@@ -57,7 +60,18 @@ privileges_level ::=
   | db_name.tbl_name
   | STAGE <stage_name>
   | UDF <udf_name>
+  | MASKING POLICY <policy_name>
 ```
+
+### 撤销脱敏策略权限
+
+```sql
+REVOKE APPLY ON MASKING POLICY <policy_name> FROM [ ROLE ] <grantee>
+REVOKE ALL [ PRIVILEGES ] ON MASKING POLICY <policy_name> FROM [ ROLE ] <grantee>
+REVOKE OWNERSHIP ON MASKING POLICY <policy_name> FROM ROLE '<role_name>'
+```
+
+以上语句用于撤销针对特定脱敏策略的 APPLY 或 OWNERSHIP 权限。若需撤销全局 `CREATE MASKING POLICY` 或 `APPLY MASKING POLICY`，可结合 `ON *.*` 使用标准语法。
 
 ### 撤销角色
 
@@ -159,4 +173,14 @@ SHOW GRANTS FOR user1;
 | GRANT ALL ON 'default'.* TO 'user1'@'%' |
 | GRANT ALL ON *.* TO 'user1'@'%'         |
 +-----------------------------------------+
+```
+
+### 示例 4：撤销脱敏策略权限
+
+```sql
+-- 撤销针对单个脱敏策略的 APPLY 权限
+REVOKE APPLY ON MASKING POLICY email_mask FROM ROLE pii_readers;
+
+-- 撤销角色在整个账号范围创建脱敏策略的权限
+REVOKE CREATE MASKING POLICY ON *.* FROM ROLE security_admin;
 ```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/02-user/22-show-grants.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/02-user/22-show-grants.md
@@ -4,7 +4,7 @@ sidebar_position: 10
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.487"/>
+<FunctionDescription description="Introduced or updated: v1.2.845"/>
 
 列出明确授予用户、角色或特定对象的权限。
 
@@ -24,7 +24,7 @@ SHOW GRANTS FOR <user_name> [ LIKE '<pattern>' | WHERE <expr> | LIMIT <limit> ]
 SHOW GRANTS FOR ROLE <role_name> [ LIKE '<pattern>' | WHERE <expr> | LIMIT <limit> ]
 
 -- 列出授予对象的权限
-SHOW GRANTS ON { STAGE | TABLE | DATABASE | UDF } <object_name> [ LIKE '<pattern>' | WHERE <expr> | LIMIT <limit> ]
+SHOW GRANTS ON { STAGE | TABLE | DATABASE | UDF | MASKING POLICY } <object_name> [ LIKE '<pattern>' | WHERE <expr> | LIMIT <limit> ]
 
 -- 列出所有已直接授予 role_name 的用户和角色。
 SHOW GRANTS OF ROLE <role_name>
@@ -89,4 +89,7 @@ SHOW GRANTS OF ROLE analyst
 │ analyst │ USER       │ user1        │
 ╰─────────────────────────────────────╯
 
+
+-- 查看脱敏策略的授权
+SHOW GRANTS ON MASKING POLICY email_mask;
 ```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/12-mask-policy/create-mask-policy.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/12-mask-policy/create-mask-policy.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="引入或更新于: v1.2.341"/>
+<FunctionDescription description="引入或更新于: v1.2.845"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -35,6 +35,14 @@ CREATE [ OR REPLACE ] MASKING POLICY [ IF NOT EXISTS ] <policy_name> AS
 :::note
 确保 *arg_type_to_mask* 与将应用脱敏策略的列的数据类型匹配。当策略包含多个参数时，必须在 `ALTER TABLE ... SET MASKING POLICY` 的 `USING` 子句中按相同顺序列出对应列。
 :::
+
+## 访问控制要求
+
+| 权限 | 描述 |
+|:-----|:-----|
+| CREATE MASKING POLICY | 创建或替换脱敏策略时所需的权限（通常授予 `*.*`）。 |
+
+策略创建成功后，Databend 会自动将该策略的 OWNERSHIP 授予当前角色，方便与其他角色协同管理该策略。
 
 ## 示例
 

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/12-mask-policy/desc-mask-policy.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/12-mask-policy/desc-mask-policy.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.45"/>
+<FunctionDescription description="引入或更新于: v1.2.845"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -18,6 +18,14 @@ import EEFeature from '@site/src/components/EEFeature';
 ```sql
 DESC MASKING POLICY <policy_name>
 ```
+
+## 访问控制要求
+
+| 权限 | 描述 |
+|:-----|:-----|
+| APPLY MASKING POLICY | 描述脱敏策略时需要具备的权限；拥有该策略的 OWNERSHIP 亦可满足要求。 |
+
+只要具备全局 `APPLY MASKING POLICY` 权限，或对指定策略拥有 APPLY/OWNERSHIP，即可查看策略定义。
 
 ## 示例
 

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/12-mask-policy/drop-mask-policy.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/12-mask-policy/drop-mask-policy.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.45"/>
+<FunctionDescription description="引入或更新于: v1.2.845"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -18,6 +18,14 @@ import EEFeature from '@site/src/components/EEFeature';
 ```sql
 DROP MASKING POLICY [ IF EXISTS ] <policy_name>
 ```
+
+## 访问控制要求
+
+| 权限 | 描述 |
+|:-----|:-----|
+| APPLY MASKING POLICY | 删除脱敏策略时需要具备的权限；如果拥有该策略的 OWNERSHIP 也可以删除。 |
+
+需要全局 `APPLY MASKING POLICY` 权限，或对目标策略拥有 APPLY/OWNERSHIP。策略删除后，Databend 会自动回收之前授予的 OWNERSHIP。
 
 ## 示例
 

--- a/docs/en/guides/56-security/access-control/01-privileges.md
+++ b/docs/en/guides/56-security/access-control/01-privileges.md
@@ -110,6 +110,7 @@ Databend offers a range of privileges that allow you to exercise fine-grained co
 | Privilege         | Object Type                   | Description                                                                                                                                        |
 |:------------------|:------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|
 | ALL               | All                           | Grants all the privileges for the specified object type.                                                                                           |
+| APPLY MASKING POLICY | Global, Masking Policy     | Attaches, detaches, describes, or drops masking policies. When granted on *.*, the grantee can manage any masking policy.                          |
 | ALTER             | Global, Database, Table, View | Alters a database, table, user or UDF.                                                                                                             |
 | CREATE            | Global, Table                 | Creates a table or UDF.                                                                                                                            |
 | CREATE DATABASE   | Global                        | Creates a database or UDF.                                                                                                                         |
@@ -117,6 +118,7 @@ Databend offers a range of privileges that allow you to exercise fine-grained co
 | CREATE CONNECTION | Global                        | Creates a connection.                                                                                                                              |
 | CREATE SEQUENCE   | Global                        | Creates a sequence.                                                                                                                                |
 | CREATE PROCEDURE  | PROCEDURE                     | Creates a procedure.                                                                                                                               |
+| CREATE MASKING POLICY | Global                    | Creates a masking policy.                                                                                                                          |
 | DELETE            | Table                         | Deletes or truncates rows in a table.                                                                                                              |
 | DROP              | Global, Database, Table, View | Drops a database, table, view or UDF. Undrops a table.                                                                                             |
 | INSERT            | Table                         | Inserts rows into a table.                                                                                                                         |
@@ -259,3 +261,11 @@ Please note that you can use the [USE DATABASE](/sql/sql-commands/ddl/database/d
 | ALL              | Grants Access Procedure privileges for the specified object type.                                                 |
 | OWNERSHIP        | Grants full control over a Procedure.  Only a single role can hold this privilege on a specific object at a time. |
 
+### Masking Policy Privileges
+
+In addition to the global `CREATE MASKING POLICY` and `APPLY MASKING POLICY` privileges, you can grant access to individual masking policies:
+
+| Privilege | Description                                                                                                                           |
+|:----------|:--------------------------------------------------------------------------------------------------------------------------------------|
+| APPLY     | Attaches or detaches the masking policy from columns, and allows DESC/DROP operations on the policy.                                  |
+| OWNERSHIP | Grants full control over a masking policy. Databend grants OWNERSHIP to the role that creates the policy and revokes it automatically when the policy is dropped. |

--- a/docs/en/guides/56-security/masking-policy.md
+++ b/docs/en/guides/56-security/masking-policy.md
@@ -81,6 +81,12 @@ SELECT * FROM user_info;
 - Ensure users have appropriate roles assigned
 - See [User & Role](/sql/sql-commands/ddl/user/) for role management
 
+### Required Privileges
+
+- Grant `CREATE MASKING POLICY` on `*.*` to any role that needs to create or replace masking policies. Databend automatically grants OWNERSHIP on a newly created policy to the current role.
+- Grant either the global `APPLY MASKING POLICY` privilege or `APPLY ON MASKING POLICY <policy_name>` to roles that attach/detach policies using `ALTER TABLE`. OWNERSHIP on the policy also allows these operations.
+- Use `SHOW GRANTS ON MASKING POLICY <policy_name>` to audit which roles can apply or own a specific policy.
+
 ## Policy Management
 
 For detailed commands to create, modify, and manage masking policies, see:

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/90-alter-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/90-alter-table.md
@@ -6,7 +6,7 @@ slug: /sql-commands/ddl/table/alter-table
  
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.821"/>
+<FunctionDescription description="Introduced or updated: v1.2.845"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -75,6 +75,7 @@ DROP [ COLUMN ] <column_name>
 - If you include `USING`, provide at least the masked column plus any additional columns needed by the policy. The first identifier in `USING (...)` must match the column being modified.
 - Masking policies can only be attached to regular tables. Views, streams, and temporary tables do not allow `SET MASKING POLICY`.
 - A column can belong to at most one security policy (masking or row-level). Remove the existing policy before attaching a new one.
+- Attaching, detaching, describing, or dropping a masking policy requires the global `APPLY MASKING POLICY` privilege or APPLY/OWNERSHIP on the specific masking policy.
 :::
 
 :::caution

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/11-revoke.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/11-revoke.md
@@ -4,7 +4,7 @@ sidebar_position: 11
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.275"/>
+<FunctionDescription description="Introduced or updated: v1.2.845"/>
 
 Revokes privileges, roles, and ownership of a specific database object. This includes:
 
@@ -48,6 +48,9 @@ schemaObjectPrivileges ::=
 
 -- For UDF
   { USAGE }
+
+-- For MASKING POLICY (account-level privileges)
+  { CREATE MASKING POLICY | APPLY MASKING POLICY }
 ```
 
 ```sql
@@ -57,7 +60,18 @@ privileges_level ::=
   | db_name.tbl_name
   | STAGE <stage_name>
   | UDF <udf_name>
+  | MASKING POLICY <policy_name>
 ```
+
+### Revoking Masking Policy Privileges
+
+```sql
+REVOKE APPLY ON MASKING POLICY <policy_name> FROM [ ROLE ] <grantee>
+REVOKE ALL [ PRIVILEGES ] ON MASKING POLICY <policy_name> FROM [ ROLE ] <grantee>
+REVOKE OWNERSHIP ON MASKING POLICY <policy_name> FROM ROLE '<role_name>'
+```
+
+Use these forms to remove access to individual masking policies. Global `CREATE MASKING POLICY` and `APPLY MASKING POLICY` privileges are revoked using the standard syntax with `ON *.*`.
 
 ### Revoking Role
 
@@ -159,4 +173,14 @@ SHOW GRANTS FOR user1;
 | GRANT ALL ON 'default'.* TO 'user1'@'%' |
 | GRANT ALL ON *.* TO 'user1'@'%'         |
 +-----------------------------------------+
+```
+
+### Example 4: Revoking Masking Policy Privileges
+
+```sql
+-- Remove per-policy access from a role
+REVOKE APPLY ON MASKING POLICY email_mask FROM ROLE pii_readers;
+
+-- Revoke the ability to create masking policies at the account level
+REVOKE CREATE MASKING POLICY ON *.* FROM ROLE security_admin;
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/22-show-grants.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/22-show-grants.md
@@ -4,7 +4,7 @@ sidebar_position: 10
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.487"/>
+<FunctionDescription description="Introduced or updated: v1.2.845"/>
 
 Lists privileges explicitly granted to a user, to a role, or on a specific object.
 
@@ -24,7 +24,7 @@ SHOW GRANTS FOR <user_name> [ LIKE '<pattern>' | WHERE <expr> | LIMIT <limit> ]
 SHOW GRANTS FOR ROLE <role_name> [ LIKE '<pattern>' | WHERE <expr> | LIMIT <limit> ]
 
 -- List privileges granted on an object
-SHOW GRANTS ON { STAGE | TABLE | DATABASE | UDF } <object_name> [ LIKE '<pattern>' | WHERE <expr> | LIMIT <limit> ]
+SHOW GRANTS ON { STAGE | TABLE | DATABASE | UDF | MASKING POLICY } <object_name> [ LIKE '<pattern>' | WHERE <expr> | LIMIT <limit> ]
 
 -- Lists all users and roles that have been directly granted role_name.
 SHOW GRANTS OF ROLE <role_name>
@@ -89,4 +89,6 @@ SHOW GRANTS OF ROLE analyst
 │ analyst │ USER       │ user1        │
 ╰─────────────────────────────────────╯
 
+-- Inspect masking policy privileges
+SHOW GRANTS ON MASKING POLICY email_mask;
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/12-mask-policy/create-mask-policy.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/12-mask-policy/create-mask-policy.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.341"/>
+<FunctionDescription description="Introduced or updated: v1.2.845"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -35,6 +35,14 @@ CREATE [ OR REPLACE ] MASKING POLICY [ IF NOT EXISTS ] <policy_name> AS
 :::note
 Ensure that *arg_type_to_mask* matches the data type of the column where the masking policy will be applied. When your policy defines multiple parameters, list each referenced column in the same order within the `USING` clause of `ALTER TABLE ... SET MASKING POLICY`.
 :::
+
+## Access Control Requirements
+
+| Privilege | Description |
+|:----------|:------------|
+| CREATE MASKING POLICY | Required to create or replace a masking policy. Typically granted on `*.*`. |
+
+Databend automatically grants OWNERSHIP on the new masking policy to the current role so that it can manage the policy with others.
 
 ## Examples
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/12-mask-policy/desc-mask-policy.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/12-mask-policy/desc-mask-policy.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.45"/>
+<FunctionDescription description="Introduced or updated: v1.2.845"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -18,6 +18,14 @@ Displays detailed information about a specific masking policy in Databend.
 ```sql
 DESC MASKING POLICY <policy_name>
 ```
+
+## Access Control Requirements
+
+| Privilege | Description |
+|:----------|:------------|
+| APPLY MASKING POLICY | Required to describe a masking policy unless you own that policy. |
+
+Either the global `APPLY MASKING POLICY` privilege or APPLY/OWNERSHIP on the specific masking policy satisfies this requirement.
 
 ## Examples
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/12-mask-policy/drop-mask-policy.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/12-mask-policy/drop-mask-policy.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.45"/>
+<FunctionDescription description="Introduced or updated: v1.2.845"/>
 
 import EEFeature from '@site/src/components/EEFeature';
 
@@ -18,6 +18,14 @@ Deletes an existing masking policy from Databend. When you drop a masking policy
 ```sql
 DROP MASKING POLICY [ IF EXISTS ] <policy_name>
 ```
+
+## Access Control Requirements
+
+| Privilege | Description |
+|:----------|:------------|
+| APPLY MASKING POLICY | Required to drop a masking policy unless you own that policy. |
+
+You must have the global `APPLY MASKING POLICY` privilege or APPLY/OWNERSHIP on the target policy. Databend automatically revokes OWNERSHIP from the creator role after the policy is dropped.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- add v1.2.845 notes and privilege requirements for CREATE/DESC/DROP masking policy commands and ALTER TABLE set/unset operations
- document new CREATE/APPLY MASKING POLICY privileges plus per-policy GRANT/REVOKE/SHOW syntax in both EN and CN references
- update security guides with new privilege tables and required-privilege guidance for masking policies

## Testing
- Not run (doc change)
