### PR TITLE
docs: refine Chinese product guide and translations

### DIFF
--- a/docs/cn/guides/00-products/index.md
+++ b/docs/cn/guides/00-products/index.md
@@ -12,11 +12,9 @@ import LanguageDocs from '@site/src/components/LanguageDocs';
 cn=
 '
 
-**Databend** —— **一套引擎撑起所有数据与场景（ANY DATA. ANY SCALE. ONE DATABASE）.**
+**Databend 是一款基于 Rust 研发的开源**云原生数仓。它通过**标准 SQL 接口**，将存储、向量、分析、搜索及地理空间引擎融为一体。无需数据迁移，即可基于对象存储实现对各类数据的存储、检索、语义分析及实时洞察。
 
-**Databend 是开源的**云原生数仓，把存储、向量搜索、SQL 分析、全文检索与地理计算统一到一套与 **Snowflake 兼容的 SQL 接口上**。所有数据都放在对象存储里，写入、分析、搜索一次到位，无需折腾多套系统。
-
-在 [**GitHub**](https://github.com/databendlabs/databend) 上探索其引擎。您可以通过 [**Databend Cloud**](https://www.databend.cn/)、`docker run` 或 `pip install databend` 启动它，每种方式都在您的对象存储上运行着同一个统一的引擎。
+访问 [**GitHub**](https://github.com/databendlabs/databend) 探索核心引擎。无论通过 [**Databend Cloud**](https://www.databend.cn/)、`docker run` 还是 `pip install databend` 启动，运行的都是同一套基于对象存储的统一引擎。
 
 '
 en=
@@ -31,38 +29,38 @@ Explore the engine on [**GitHub**](https://github.com/databendlabs/databend). La
 '/>
 <DocsOverview />
 
-**推荐先从这些主题开始了解**
+**核心主题概览：**
 
 **快速上手**
 
-- **[快速开始](/guides/deploy/quickstart)**: 用 Docker 几分钟内启动 Databend，并加载示例数据。
-- **[Databend Cloud](/guides/cloud)**: 创建无服务器仓库，集中管理组织与资源。
-- **[连接到 Databend](/guides/sql-clients)**: 通过常见 SQL 客户端或编程语言接入 Databend。
-- **[SQL 参考](/sql)**: 查询 Databend 支持的 SQL 命令、函数与语法。
+- **[快速开始](/guides/deploy/quickstart)**: 使用 Docker 快速启动 Databend，加载示例数据并体验核心功能。
+- **[Databend Cloud](/guides/cloud)**: 创建 Serverless 数仓，高效管理组织与数据资源。
+- **[连接 Databend](/guides/sql-clients)**: 支持主流 SQL 客户端及编程语言，连接并使用 Databend。
+- **[SQL 参考](/sql)**: 查阅 Databend 支持的 SQL 命令、函数及语法详情。
 
 **数据处理**
 
-- **[数据加载](/guides/load-data)**: 把不同来源的数据导入 Databend。
-- **[数据卸载](/guides/unload-data)**: 将 Databend 数据导出为所需格式。
-- **[半结构化数据](/sql/sql-functions/semi-structured-functions)**: 借助 VARIANT 处理 JSON、数组与嵌套结构。
+- **[数据加载](/guides/load-data)**: 支持从多种数据源高效导入数据。
+- **[数据卸载](/guides/unload-data)**: 将数据导出为多种格式，满足下游处理需求。
+- **[半结构化数据](/sql/sql-functions/semi-structured-functions)**: 利用 VARIANT 类型，高效处理 JSON、数组及嵌套数据。
 
-**统一引擎场景**
+**统一分析场景**
 
-- **[SQL 分析指南](/guides/query/sql-analytics)**: 用同一套引擎支撑分析、搜索、向量与地理任务。
-- **[JSON 与搜索指南](/guides/query/json-search)**: 依托倒排索引和 Elasticsearch 风格 `QUERY` 检索 VARIANT 载荷。
-- **[向量数据库指南](/guides/query/vector-db)**: 在 Databend 内存储嵌入并完成语义相似检索。
-- **[地理分析指南](/guides/query/geo-analytics)**: 借助地理空间 SQL 绘制事件地图，实时定位热点。
-- **[湖仓 ETL 指南](/guides/query/lakehouse-etl)**: 将对象存储文件流式写入托管表，杜绝数据孤岛。
+- **[SQL 分析指南](/guides/query/sql-analytics)**: 基于统一平台，处理分析、搜索、向量及地理空间任务。
+- **[JSON 与搜索指南](/guides/query/json-search)**: 结合倒排索引与 Elasticsearch 语法，实现 VARIANT 数据的高效检索。
+- **[向量数据库指南](/guides/query/vector-db)**: 原生存储向量数据（Embeddings），直接在 SQL 中进行语义相似度计算。
+- **[地理分析指南](/guides/query/geo-analytics)**: 利用地理空间 SQL 能力，进行地图绘制与位置分析。
+- **[湖仓 ETL 指南](/guides/query/lakehouse-etl)**: 将对象存储文件流式写入托管表，消除数据孤岛。
 
 **性能与扩展**
 
-- **[性能优化](/guides/performance)**: 结合多种策略加速查询与计算。
-- **[基准测试](/guides/benchmark)**: 了解 Databend 与其他数据仓库的性能对比。
-- **[数据湖仓](/sql/sql-reference/table-engines)**: 与 Hive、Iceberg、Delta Lake 无缝协作。
+- **[性能优化](/guides/performance)**: 了解核心优化策略，提升查询性能。
+- **[基准测试](/guides/benchmark)**: 查看 Databend 与其他数仓的性能对比报告。
+- **[数据湖仓](/sql/sql-reference/table-engines)**: 集成 Hive, Iceberg 和 Delta Lake，构建开放的数据湖仓。
 
 **社区与支持**
 
-- **[加入 Slack](https://link.databend.com/join-slack)**: 与社区成员及核心工程师直接交流。
-- **[文档问题](https://github.com/databendlabs/databend-docs/issues)**: 反馈文档缺失或提交改进建议。
-- **[路线图](https://github.com/databendlabs/databend/issues/14167)**: 跟踪即将发布的功能并留下意见。
-- **[邮件联系](mailto:hi@databend.com)**: 需要即时协助时写信给我们。
+- **[加入 Slack](https://link.databend.com/join-slack)**: 加入社区，与核心开发团队及用户交流。
+- **[文档反馈](https://github.com/databendlabs/databend-docs/issues)**: 提交文档问题或改进建议。
+- **[路线图](https://github.com/databendlabs/databend/issues/14167)**: 关注开发计划，了解未来功能规划。
+- **[联系我们](mailto:hi@databend.com)**: 如需帮助，请邮件联系我们。

--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -502,7 +502,7 @@
     "description": "学习如何使用 Databend 的描述"
   },
   "Quick Start": {
-    "message": "快速入门",
+    "message": "快速开始",
     "description": "快速入门部分的标题"
   },
   "Get started with Databend in 5 minutes": {
@@ -522,19 +522,19 @@
     "description": "Databend Cloud 部分的描述"
   },
   "Connect to Databend": {
-    "message": "连接 Databend",
+    "message": "客户端连接",
     "description": "连接到 Databend 部分的标题"
   },
   "Developer Resources": {
-    "message": "开发者资源",
+    "message": "开发者",
     "description": "开发者资源的链接文字"
   },
   "Connect your application to Databend in just a few minutes.": {
-    "message": "几分钟内就能让应用接入 Databend。",
+    "message": "仅需几分钟，即可将您的应用连接至 Databend。",
     "description": "连接到 Databend 部分的描述"
   },
   "Load Data into Databend": {
-    "message": "向 Databend 加载数据",
+    "message": "数据导入",
     "description": "加载数据到 Databend 部分的标题"
   },
   "Know More": {
@@ -542,7 +542,7 @@
     "description": "了解更多的链接文字"
   },
   "Bulk import data into Databend(Cloud) in multiple formats.": {
-    "message": "以多种格式批量把数据导入 Databend（含 Cloud）。",
+    "message": "支持多种格式，批量将数据导入 Databend 及 Databend Cloud。",
     "description": "加载数据到 Databend 部分的描述"
   },
   "AI & BI & Visualization & Notebooks": {
@@ -554,7 +554,7 @@
     "description": "所有工具的链接文字"
   },
   "Databend offers connectors and plugins for integrating with major data import tools, ensuring efficient data synchronization.": {
-    "message": "Databend 提供主流导入工具的连接器与插件，保障高效同步。",
+    "message": "提供主流工具的连接器与插件，确保与现有生态的无缝集成与高效同步。",
     "description": "AI & BI & 可视化 & 笔记本 部分的描述"
   },
   "Continuous Data Pipelines": {
@@ -562,7 +562,7 @@
     "description": "连续数据管道部分的标题"
   },
   "Data pipelines automate the process of moving and changing data from different sources into Databend.": {
-    "message": "数据管道自动完成多源采集、转换并写入 Databend。",
+    "message": "自动化数据管道，轻松实现多源数据的采集、转换与写入。",
     "description": "连续数据管道部分的描述"
   },
   "Real-Time CDC Ingestion": {
@@ -582,7 +582,7 @@
     "description": "AI 功能的文本"
   },
   "Databend Products": {
-    "message": "Databend 的产品",
+    "message": "产品",
     "description": "Databend 产品的文本"
   },
   "Security": {
@@ -594,47 +594,15 @@
     "description": "联系支持的文本"
   },
   "Pricing": {
-    "message": "价格相关",
+    "message": "性能",
     "description": "价格的文本"
   },
   "Use Cases": {
     "message": "典型场景",
     "description": "Use Cases"
   },
-  "Introduction to Databend Products": {
-    "message": "Databend 产品导览",
-    "description": "Databend 产品介绍部分的标题"
-  },
-  "Choose the deployment option that best fits your needs and scale.": {
-    "message": "按业务规模选择最合适的部署方式。",
-    "description": "Databend 产品介绍部分的描述"
-  },
-  "Databend Cloud": {
-    "message": "Databend Cloud",
-    "description": "Databend Cloud 产品的标题"
-  },
-  "Fully-managed cloud service. No setup required.": {
-    "message": "全托管云服务，开箱即可使用。",
-    "description": "Databend Cloud 产品的描述"
-  },
-  "Databend Enterprise": {
-    "message": "Databend 企业版",
-    "description": "Databend Enterprise 产品的标题"
-  },
-  "Self-hosted with enterprise features and support.": {
-    "message": "自主部署，配备企业级功能与支持。",
-    "description": "Databend Enterprise 产品的描述"
-  },
-  "Databend Community": {
-    "message": "Databend 社区版",
-    "description": "Databend 社区版 产品的标题"
-  },
-  "Open-source and free for all use cases.": {
-    "message": "开源且永久免费。",
-    "description": "Databend 社区版 产品的描述"
-  },
   "Getting Started": {
-    "message": "快速入门",
+    "message": "快速开始",
     "description": "入门指南部分的标题"
   },
   "Create a Databend Cloud account or deploy your own Databend instance.": {
@@ -674,7 +642,7 @@
     "description": "自托管 Databend 卡片的描述"
   },
   "Downloading Databend": {
-    "message": "下载 Databend",
+    "message": "下载",
     "description": "下载 Databend 的链接文字"
   },
   "Licensing Databend": {
@@ -694,11 +662,11 @@
     "description": "FAQ"
   },
   "Product Features": {
-    "message": "产品特性",
+    "message": "核心特性",
     "description": "Product Features"
   },
   "Unified Engine": {
-    "message": "统一引擎",
+    "message": "统一计算引擎",
     "description": "Headline for unified engine feature"
   },
   "NoDesc": {
@@ -718,55 +686,55 @@
     "description": "Stores all data in object storage."
   },
   "Analytics, vector, search, and geo share one optimizer and runtime.": {
-    "message": "分析、向量、搜索与地理能力共用一套优化器和执行引擎。",
+    "message": "分析、向量、搜索与地理计算，统一架构，一套引擎全覆盖。",
     "description": "Description for unified engine feature"
   },
   "Unified Data": {
-    "message": "统一数据层",
+    "message": "统一数据底座",
     "description": "Headline for unified data feature"
   },
   "Structured, semi-structured, unstructured, and vector data share object storage.": {
-    "message": "结构化、半结构化、非结构化与向量数据共享同一对象存储。",
+    "message": "结构化、半结构化与向量数据，统一存储，一份数据支撑全业务。",
     "description": "Description for unified data feature"
   },
   "Analytics Native": {
-    "message": "原生分析引擎",
+    "message": "原生 SQL 分析(Analytics)",
     "description": "Headline for analytics native feature"
   },
   "ANSI SQL, windowing, incremental aggregates, and streaming power BI.": {
-    "message": "ANSI SQL、窗口函数、增量聚合与流式处理为 BI 持续供能。",
+    "message": "兼容标准 SQL，支持流式聚合，为 BI 分析注入实时动力。",
     "description": "Description for analytics native feature"
   },
   "Vector Native": {
-    "message": "原生向量能力",
+    "message": "原生向量支持(Vector)",
     "description": "Headline for vector native feature"
   },
   "Embeddings, vector indexes, and semantic retrieval all run in SQL.": {
-    "message": "向量嵌入、索引与语义检索全部在 SQL 中完成。",
+    "message": "向量数据与语义检索，皆可使用 SQL 直接完成。",
     "description": "Description for vector native feature"
   },
   "Search Native": {
-    "message": "原生搜索能力",
+    "message": "原生搜索能力(Search)",
     "description": "Headline for search native feature"
   },
-  "JSON inverted indexes, geo functions, and ranking fuel hybrid maps.": {
-    "message": "JSON 倒排索引、地理函数与排序能力共同驱动混合检索。",
+  "Full-text search and inverted indexes fuel hybrid retrieval.": {
+    "message": "融合倒排索引与全文检索，高效支撑混合检索应用。",
     "description": "Description for search native feature"
   },
-  "Unified Deployment": {
-    "message": "统一部署选择",
-    "description": "Headline for unified deployment feature"
+  "Geo Native": {
+    "message": "原生地理空间(Geospatial)",
+    "description": "Headline for geo native feature"
   },
-  "Databend runs the same in Cloud, Docker, or `pip install`.": {
-    "message": "无论 Cloud、Docker 还是 `pip install`,体验的都是同一个 Databend 引擎。",
-    "description": "Description for unified deployment feature"
+  "Geospatial indexes and functions power map and location services.": {
+    "message": "支持地理空间数据检索与分析，高效支撑地图与位置服务。",
+    "description": "Description for geo native feature"
   },
   "Start with Databend Cloud": {
     "message": "从 Databend Cloud 起步",
     "description": "Start with Databend Cloud"
   },
   "Get started in minutes with our fully-managed cloud service. No setup required.": {
-    "message": "几分钟即可启用全托管云服务，无需任何额外配置。",
+    "message": "几分钟内即可启用全托管云服务，无需任何配置。",
     "description": "Get started in minutes with our fully-managed cloud service. No setup required."
   },
   "What you need to know:": {
@@ -786,11 +754,11 @@
     "description": "Using Databend Cloud"
   },
   "Deploy Your Own Instance": {
-    "message": "自主部署实例",
+    "message": "部署您的私有实例",
     "description": "Deploy Your Own Instance"
   },
   "Install Databend on your infrastructure for complete control and customization.": {
-    "message": "在自有基础设施上安装 Databend，配置完全可控。",
+    "message": "在您的基础设施上安装 Databend，实现完全的掌控与定制。",
     "description": "Install Databend on your infrastructure for complete control and customization."
   },
   "5-Minute Quick Start": {
@@ -830,16 +798,12 @@
     "description": "Copying..."
   },
   "DOCUMENTATION": {
-    "message": "文档",
+    "message": "文档首页",
     "description": "DOCUMENTATION"
   },
   "Raise issue": {
     "message": "提 issue",
     "description": "Raise issue"
-  },
-  "Search & Geo Native": {
-    "message": "原生搜索与地理",
-    "description": "Headline for search native feature"
   },
   "Ask questions about this page": {
     "message": "询问关于此页面的问题",
@@ -848,5 +812,41 @@
   "Open in": {
     "message": "打开",
     "description": "Open in"
+  },
+  "Products": {
+    "message": "产品",
+    "description": "Products"
+  },
+  "Performance": {
+    "message": "性能",
+    "description": "Performance"
+  },
+  "Downloads": {
+    "message": "下载",
+    "description": "Downloads"
+  },
+  "RESOURCES": {
+    "message": "资源",
+    "description": "RESOURCES"
+  },
+  "COMMUNITY": {
+    "message": "社区",
+    "description": "COMMUNITY"
+  },
+  "Tutorials": {
+    "message": "教程",
+    "description": "Tutorials"
+  },
+  "SQL Reference": {
+    "message": "SQL 参考",
+    "description": "SQL Reference"
+  },
+  "Integrations": {
+    "message": "集成",
+    "description": "Integrations"
+  },
+  "Releases": {
+    "message": "版本发布",
+    "description": "Releases"
   }
 }

--- a/src/components/DocsOverview/index.tsx
+++ b/src/components/DocsOverview/index.tsx
@@ -57,58 +57,7 @@ const DocsOverview: FC = (): ReactElement => {
   } = useDocusaurusContext();
   return (
     <div className={styles.outWrap}>
-      <ContentCardWrap
-        className={styles.top}
-        title={$t("Introduction to Databend Products")}
-        description={$t(
-          "Choose the deployment option that best fits your needs and scale."
-        )}
-      >
-        <div style={{ height: "100%", width: "100%" }}>
-          <Row gutter={[12, 12]} className={styles.topCard}>
-            <Col {...colLayout3}>
-              <Card
-                title={$t("Databend Cloud")}
-                href="/guides/products/dc/"
-                padding={[16, 16]}
-              >
-                <h3>
-                  <span>{$t("Databend Cloud")}</span>
-                </h3>
-                <div>
-                  {$t("Fully-managed cloud service. No setup required.")}
-                </div>
-              </Card>
-            </Col>
-            <Col {...colLayout3}>
-              <Card
-                title={$t("Databend Enterprise")}
-                href="/guides/products/dee/"
-                padding={[16, 16]}
-              >
-                <h3>
-                  <span>{$t("Databend Enterprise")}</span>
-                </h3>
-                <div>
-                  {$t("Self-hosted with enterprise features and support.")}
-                </div>
-              </Card>
-            </Col>
-            <Col {...colLayout3}>
-              <Card
-                title={$t("Databend Community")}
-                href="/guides/products/dce/"
-                padding={[16, 16]}
-              >
-                <h3>
-                  <span>{$t("Databend Community")}</span>
-                </h3>
-                <div>{$t("Open-source and free for all use cases.")}</div>
-              </Card>
-            </Col>
-          </Row>
-        </div>
-      </ContentCardWrap>
+
       <div
         className={styles.productFeatures}
         style={{ height: "100%", width: "100%" }}
@@ -158,20 +107,20 @@ const DocsOverview: FC = (): ReactElement => {
           <Col {...colLayout2}>
             <Card style={{ height: "100%" }} padding={[16, 16]}>
               <h3>
-                <span>{$t("Search & Geo Native")}</span>
+                <span>{$t("Search Native")}</span>
               </h3>
               <div>
-                {$t("JSON inverted indexes, geo functions, and ranking fuel hybrid maps.")}
+                {$t("Full-text search and inverted indexes fuel hybrid retrieval.")}
               </div>
             </Card>
           </Col>
           <Col {...colLayout2}>
             <Card style={{ height: "100%" }} padding={[16, 16]}>
               <h3>
-                <span>{$t("Unified Deployment")}</span>
+                <span>{$t("Geo Native")}</span>
               </h3>
               <div>
-                {$t("Databend runs the same in Cloud, Docker, or `pip install`.")}
+                {$t("Geospatial indexes and functions power map and location services.")}
               </div>
             </Card>
           </Col>
@@ -257,7 +206,7 @@ const DocsOverview: FC = (): ReactElement => {
                     <li>
                       <Link
                         title={$t("5-Minute Quick Start")}
-                  to={"/guides/deploy/quickstart/"}
+                        to={"/guides/deploy/quickstart/"}
                       >
                         {$t("5-Minute Quick Start")}
                       </Link>


### PR DESCRIPTION
## Summary

This PR refines the Chinese product guide and translations to be more professional, natural, and concise.

## Changes

- **Product Description**: Refined the slogan and description in `docs/cn/guides/00-products/index.md` to remove colloquialisms and improve flow. Added mention of Rust.
- **Feature Cards**:
    - Split 'Search & Geo Native' into separate 'Search Native' and 'Geo Native' cards in `DocsOverview`.
    - Removed the 'Unified Deployment' card to reduce redundancy.
    - Removed the 'Introduction to Databend Products' section.
- **Translations**: Updated `i18n/zh/code.json` with improved translations for core features, using 'Chinese (English)' format for titles.

## Visuals

- Verified locally that the new card layout and text render correctly.