### PR TITLE
docs: improve copy_history syntax docs

### DIFF
--- a/docs/cn/sql-reference/00-sql-reference/31-system-tables/system-copy-history.md
+++ b/docs/cn/sql-reference/00-sql-reference/31-system-tables/system-copy-history.md
@@ -8,8 +8,16 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 包含 COPY 历史的相关信息。
 
+## Syntax
+
 ```sql
-select * from copy_history('abc');
+SELECT * FROM copy_history('<table_name>');
+```
+
+- `table_name`: 表名。
+
+```sql
+select * from copy_history('my_table');
 
 ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │                          file_name                          │ content_length │        last_modified       │       etag       │

--- a/docs/en/sql-reference/00-sql-reference/31-system-tables/system-copy-history.md
+++ b/docs/en/sql-reference/00-sql-reference/31-system-tables/system-copy-history.md
@@ -8,8 +8,16 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 Contains information about copy history.
 
+## Syntax
+
 ```sql
-select * from copy_history('abc');
+SELECT * FROM copy_history('<table_name>');
+```
+
+- `table_name`: The table name.
+
+```sql
+select * from copy_history('my_table');
 
 ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │                          file_name                          │ content_length │        last_modified       │       etag       │


### PR DESCRIPTION
Use explicit table name in syntax and examples for `copy_history` system table function.\nThis clarifies that the function accepts a single argument which is the table name.\n\nChanges:\n- Add Syntax section to both CN and EN docs.\n- Update example to use `my_table` instead of `abc` to be less confusing.