### PR TITLE
fix: remove broken OpenDAL presign RFC link

### DIFF
--- a/docs/cn/developer/20-community/02-rfcs/20220704-presign.md
+++ b/docs/cn/developer/20-community/02-rfcs/20220704-presign.md
@@ -71,7 +71,7 @@ MySQL [(none)]> PRESIGN UPLOAD @my_stage/books.csv
 
 `PRESIGN` 将作为语句而不是函数来实现，以便我们可以同时返回 HTTP 方法、headers 和 URL。
 
-大多数工作已通过 [Apache OpenDAL presign](https://opendal.apache.org/docs/rust/opendal/docs/rfcs/rfc_0413_presign/index.html) 完成。
+大多数工作已通过 Apache OpenDAL presign 完成。
 
 语法将是：
 

--- a/docs/en/developer/20-community/02-rfcs/20220704-presign.md
+++ b/docs/en/developer/20-community/02-rfcs/20220704-presign.md
@@ -71,7 +71,7 @@ MySQL [(none)]> PRESIGN UPLOAD @my_stage/books.csv
 
 `PRESIGN` will be implemented as a statement instead of a function so that we can return the HTTP method, headers, and URL at the same time.
 
-Most jobs have been done via [Apache OpenDAL presign](https://opendal.apache.org/docs/rust/opendal/docs/rfcs/rfc_0413_presign/index.html).
+Most jobs have been done via Apache OpenDAL presign.
 
 The syntax will be:
 


### PR DESCRIPTION
## Summary
- Remove broken link to Apache OpenDAL presign RFC documentation that returns 404
- Updated both EN and CN versions of the presign RFC doc

## Test plan
- [x] Link checker should pass after this fix

Fixes #3024