### PR TITLE
docs: add task dynamic SQL example

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/04-task/01-ddl-create_task.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/04-task/01-ddl-create_task.md
@@ -144,16 +144,16 @@ END;
 ### 动态 SQL（EXECUTE IMMEDIATE）
 
 ```sql
-CREATE OR REPLACE TASK alb_log_ingestion
+CREATE OR REPLACE TASK log_ingestion
   WAREHOUSE = 'default'
-  SCHEDULE = USING CRON '0 * * * * *' 'Asia/Shanghai'
+  SCHEDULE = 1 MINUTE
 AS
 EXECUTE IMMEDIATE $$
 BEGIN
     LET path := CONCAT('@mylog/', DATE_FORMAT(CURRENT_DATE - INTERVAL 3 DAY, '%m/%d/'));
 
     LET sql := CONCAT(
-        'COPY INTO logs.alb_logs FROM ', path,
+        'COPY INTO logs.web_logs FROM ', path,
         ' PATTERN = ''.*[.]gz'' FILE_FORMAT = (type = NDJSON compression = AUTO) MAX_FILES = 10000'
     );
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/04-task/01-ddl-create_task.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/04-task/01-ddl-create_task.md
@@ -144,16 +144,16 @@ This example creates a task named `nightly_refresh` that executes a script conta
 ### Dynamic SQL (EXECUTE IMMEDIATE)
 
 ```sql
-CREATE OR REPLACE TASK alb_log_ingestion
+CREATE OR REPLACE TASK log_ingestion
   WAREHOUSE = 'default'
-  SCHEDULE = USING CRON '0 * * * * *' 'Asia/Shanghai'
+  SCHEDULE = 1 MINUTE
 AS
 EXECUTE IMMEDIATE $$
 BEGIN
     LET path := CONCAT('@mylog/', DATE_FORMAT(CURRENT_DATE - INTERVAL 3 DAY, '%m/%d/'));
 
     LET sql := CONCAT(
-        'COPY INTO logs.alb_logs FROM ', path,
+        'COPY INTO logs.web_logs FROM ', path,
         ' PATTERN = ''.*[.]gz'' FILE_FORMAT = (type = NDJSON compression = AUTO) MAX_FILES = 10000'
     );
 


### PR DESCRIPTION
Adds a CREATE TASK example that uses EXECUTE IMMEDIATE to build and run a dynamic COPY INTO for the partition path of 3 days ago, scheduled every minute.