### PR TITLE
docs: update wizardbend ORC sample-data path

### DIFF
--- a/docs/cn/guides/40-load-data/03-load-semistructured/04-load-orc.md
+++ b/docs/cn/guides/40-load-data/03-load-semistructured/04-load-orc.md
@@ -36,7 +36,7 @@ CREATE OR REPLACE CONNECTION aws_s3
     SECRET_ACCESS_KEY='your-sk';
 
 CREATE OR REPLACE STAGE orc_data_stage
-    URL='s3://wizardbend/sample-data/orc/'
+    URL='s3://wizardbend/databend-doc/sample-data/orc/'
     CONNECTION=(CONNECTION_NAME='aws_s3');
 ```
 

--- a/docs/en/guides/40-load-data/03-load-semistructured/04-load-orc.md
+++ b/docs/en/guides/40-load-data/03-load-semistructured/04-load-orc.md
@@ -36,7 +36,7 @@ CREATE OR REPLACE CONNECTION aws_s3
     SECRET_ACCESS_KEY='your-sk';
 
 CREATE OR REPLACE STAGE orc_data_stage
-    URL='s3://wizardbend/sample-data/orc/'
+    URL='s3://wizardbend/databend-doc/sample-data/orc/'
     CONNECTION=(CONNECTION_NAME='aws_s3');
 ```
 


### PR DESCRIPTION
This pull request updates the S3 URL used in the ORC data loading documentation for both the Chinese and English guides. The change ensures that the sample data path is consistent and points to the correct location.

Documentation updates:

* Updated the S3 URL in the `CREATE OR REPLACE STAGE orc_data_stage` example from `s3://wizardbend/sample-data/orc/` to `s3://wizardbend/databend-doc/sample-data/orc/` in `docs/cn/guides/40-load-data/03-load-semistructured/04-load-orc.md`
* Updated the S3 URL in the `CREATE OR REPLACE STAGE orc_data_stage` example from `s3://wizardbend/sample-data/orc/` to `s3://wizardbend/databend-doc/sample-data/orc/` in `docs/en/guides/40-load-data/03-load-semistructured/04-load-orc.md`