### PR TITLE
docs: fix MCP CLI command syntax for Codex and Claude Code

### DIFF
--- a/docs/cn/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/cn/guides/51-ai-functions/03-mcp-integration.md
@@ -38,7 +38,10 @@ import TabItem from '@theme/TabItem';
 <TabItem value="codex" label="Codex">
 
 ```bash
-codex mcp add databend -- -e DATABEND_DSN="databend://user:password@host:port/database?warehouse=your_warehouse" -e SAFE_MODE=false -- uv tool run mcp-databend
+codex mcp add databend \
+  --env DATABEND_DSN='databend://user:password@host:port/database?warehouse=your_warehouse' \
+  --env SAFE_MODE='false' \
+  -- uv tool run mcp-databend
 ```
 
 或添加到 `~/.codex/config.toml`:
@@ -58,7 +61,10 @@ SAFE_MODE = "false"
 <TabItem value="claude-code" label="Claude Code">
 
 ```bash
-claude mcp add databend -e DATABEND_DSN="databend://user:password@host:port/database?warehouse=your_warehouse" -e SAFE_MODE=false -- uv tool run mcp-databend
+claude mcp add databend \
+  --env DATABEND_DSN='databend://user:password@host:port/database?warehouse=your_warehouse' \
+  --env SAFE_MODE='false' \
+  -- uv tool run mcp-databend
 ```
 
 </TabItem>

--- a/docs/en/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/en/guides/51-ai-functions/03-mcp-integration.md
@@ -38,7 +38,10 @@ We recommend using **Databend Cloud** for the best experience.
 <TabItem value="codex" label="Codex">
 
 ```bash
-codex mcp add databend -- -e DATABEND_DSN="databend://user:password@host:port/database?warehouse=your_warehouse" -e SAFE_MODE=false -- uv tool run mcp-databend
+codex mcp add databend \
+  --env DATABEND_DSN='databend://user:password@host:port/database?warehouse=your_warehouse' \
+  --env SAFE_MODE='false' \
+  -- uv tool run mcp-databend
 ```
 
 Or add to `~/.codex/config.toml`:
@@ -58,7 +61,10 @@ SAFE_MODE = "false"
 <TabItem value="claude-code" label="Claude Code">
 
 ```bash
-claude mcp add databend -e DATABEND_DSN="databend://user:password@host:port/database?warehouse=your_warehouse" -e SAFE_MODE=false -- uv tool run mcp-databend
+claude mcp add databend \
+  --env DATABEND_DSN='databend://user:password@host:port/database?warehouse=your_warehouse' \
+  --env SAFE_MODE='false' \
+  -- uv tool run mcp-databend
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

- Fixed MCP CLI command syntax for Codex and Claude Code in the MCP integration documentation
- Changed `-e` flag to `--env` for proper environment variable passing
- Reformatted commands with line continuations for better readability

## Changes

- `docs/en/guides/51-ai-functions/03-mcp-integration.md`
- `docs/cn/guides/51-ai-functions/03-mcp-integration.md`