### PR TITLE
docs: remove dead link to sundy-li blog post

### DIFF
--- a/docs/cn/developer/20-community/02-rfcs/20220729-recluster.md
+++ b/docs/cn/developer/20-community/02-rfcs/20220729-recluster.md
@@ -13,8 +13,6 @@ description: RFC for recluster a clustered table
 
 ## 设计
 
-有关更详细的原则和图片，请参考 [snowflake auto clustering](https://sundy-li.github.io/posts/探索snowflake-auto-clustering/)。
-
 执行全表排序的成本非常高，特别是对于不断有新数据流入的表。为了在高效修剪和低成本之间取得平衡，表只需要大致排序，而不是完全排序。因此，在 [指标](#metrics) 中引入了两个指标来确定表是否聚簇良好。重新聚簇的目标是减少 `overlap` 和 `depth`。
 
 为了避免多次重复处理同一块数据，我们将块分成不同的级别，类似于 LSM 树。重新聚簇类似于 LSM 压缩操作。`level` 表示该块中的数据已被聚簇的次数。重新聚簇操作在同一级别上执行。

--- a/docs/en/developer/20-community/02-rfcs/20220729-recluster.md
+++ b/docs/en/developer/20-community/02-rfcs/20220729-recluster.md
@@ -13,8 +13,6 @@ By default, data is stored in tables according to natural dimensions. We need to
 
 ## Design
 
-For more detailed principles and pictures, please refer to [snowflake auto clustering](https://sundy-li.github.io/posts/探索snowflake-auto-clustering/).
-
 The cost of performing full table sorting is very expensive, especially for the tables that constantly have new data inflow. In order to make a balance between efficient pruning and low cost, the tables only need to be roughly sorted instead of fully sorted. Therefore, two metrics are introduced in [Metrics](#metrics) to determine whether the table is well clustered. The goal of recluster is to reduce `overlap` and `depth`.
 
 To avoid churning on the same piece of data many times, we divides the blocks into different levels like LSM trees. The recluster is similar to the LSM compact operation. The `level` represents the number of times the data in that block has been clustered. The recluster operation is performed on the same level.


### PR DESCRIPTION
## Summary

Remove dead link to sundy-li's blog post about Snowflake auto clustering from the recluster RFC documents.

The link `https://sundy-li.github.io/posts/探索snowflake-auto-clustering/` returns HTTP 404.

Fixes #3049

## Changes

- Removed dead link from `docs/en/developer/20-community/02-rfcs/20220729-recluster.md`
- Removed dead link from `docs/cn/developer/20-community/02-rfcs/20220729-recluster.md`