### PR TITLE
Rename db-archiver references

### DIFF
--- a/docs/cn/tutorials/index.md
+++ b/docs/cn/tutorials/index.md
@@ -26,7 +26,7 @@ description: 查找覆盖连接、摄取、迁移、开发与运维 Databend 的
 - [使用 Debezium 实时同步 MySQL](/tutorials/migrate/migrating-from-mysql-with-debezium)
 - [使用 Flink CDC 实时同步 MySQL](/tutorials/migrate/migrating-from-mysql-with-flink-cdc)
 - [使用 Kafka Connect 实时同步 MySQL](/tutorials/migrate/migrating-from-mysql-with-kafka-connect)
-- [使用 db-archiver 离线迁移 MySQL](/tutorials/migrate/migrating-from-mysql-with-db-archiver)
+- [使用 bend-archiver 离线迁移 MySQL](/tutorials/migrate/migrating-from-mysql-with-db-archiver)
 - [使用 DataX 离线迁移 MySQL](/tutorials/migrate/migrating-from-mysql-with-datax)
 - [使用 Addax 离线迁移 MySQL](/tutorials/migrate/migrating-from-mysql-with-addax)
 - [从 Snowflake 迁移数据](/tutorials/migrate/migrating-from-snowflake)

--- a/docs/cn/tutorials/migrate/index.md
+++ b/docs/cn/tutorials/migrate/index.md
@@ -12,7 +12,7 @@ Databend 支持两类主要迁移方式：
 
 | 迁移方式 | 推荐工具 | 支持的 MySQL 版本 |
 |----------|----------|-------------------|
-| 批量加载 | db-archiver | 所有 MySQL 版本 |
+| 批量加载 | bend-archiver | 所有 MySQL 版本 |
 | 以 CDC 实时同步 | Debezium | 所有 MySQL 版本 |
 
 ### 何时选择实时迁移（CDC）
@@ -30,7 +30,7 @@ Databend 支持两类主要迁移方式：
 
 ### 何时选择批量迁移
 
-> **推荐**：批量迁移优先选择 **db-archiver**。
+> **推荐**：批量迁移优先选择 **bend-archiver**。
 
 - 需要一次性或定期批量迁移
 - 需要迁移大量历史数据
@@ -38,7 +38,7 @@ Databend 支持两类主要迁移方式：
 
 | 工具 | 能力 | 最适合场景 | 适用情形 |
 |------|------|------------|----------|
-| [db-archiver](/tutorials/migrate/migrating-from-mysql-with-db-archiver) | 全量、增量 | 高效归档历史数据 | 数据按时间分区；需要归档历史；希望轻量化工具 |
+| [bend-archiver](/tutorials/migrate/migrating-from-mysql-with-db-archiver) | 全量、增量 | 高效归档历史数据 | 数据按时间分区；需要归档历史；希望轻量化工具 |
 | [DataX](/tutorials/migrate/migrating-from-mysql-with-datax) | 全量、增量 | 大规模数据高速迁移 | 需要高吞吐；希望并行处理；需要成熟广泛使用的工具 |
 | [Addax](/tutorials/migrate/migrating-from-mysql-with-addax) | 全量、增量 | DataX 增强版，更高性能 | 相比 DataX 需要更好的错误处理；想要监控增强；希望使用更新的功能 |
 

--- a/docs/cn/tutorials/migrate/migrating-from-mysql-with-db-archiver.md
+++ b/docs/cn/tutorials/migrate/migrating-from-mysql-with-db-archiver.md
@@ -1,19 +1,19 @@
 ---
-title: 使用 db-archiver 离线迁移 MySQL
-sidebar_label: 'db-archiver 离线迁移 MySQL'
+title: 使用 bend-archiver 离线迁移 MySQL
+sidebar_label: 'bend-archiver 离线迁移 MySQL'
 ---
 
 > **能力**：全量、增量  
 > **✅ 推荐**：批量迁移历史数据
 
-本教程将演示如何通过 db-archiver 将 MySQL 迁移到 Databend Cloud。
+本教程将演示如何通过 bend-archiver 将 MySQL 迁移到 Databend Cloud。
 
 ## 开始之前
 
 请准备以下环境：
 
 - 本地安装 [Docker](https://www.docker.com/)，用于启动 MySQL。
-- 本地安装 [Go](https://go.dev/dl/)，用于安装 db-archiver。
+- 本地安装 [Go](https://go.dev/dl/)，用于安装 bend-archiver。
 - 本地安装 BendSQL，参见 [安装 BendSQL](/guides/connect/sql-clients/bendsql/#installing-bendsql)。
 
 ## 步骤 1：在 Docker 中启动 MySQL
@@ -98,11 +98,11 @@ CREATE TABLE my_table (
 );
 ```
 
-## 步骤 4：安装 db-archiver
+## 步骤 4：安装 bend-archiver
 
-从 [Releases](https://github.com/databendcloud/db-archiver/releases/) 下载适合你架构的版本。
+从 [Releases](https://github.com/databendlabs/bend-archiver/releases/) 下载适合你架构的版本。
 
-## 步骤 5：配置并运行 db-archiver
+## 步骤 5：配置并运行 bend-archiver
 
 1. 新建本地文件 **conf.json**：
 
@@ -133,7 +133,7 @@ CREATE TABLE my_table (
 2. 在 conf.json 所在目录运行：
 
 ```bash
-db-archiver -f conf.json
+bend-archiver -f conf.json
 ```
 
 控制台将显示迁移进度：
@@ -141,7 +141,7 @@ db-archiver -f conf.json
 ```bash
 start time: 2025-01-22 21:45:33
 ...
-INFO[0001] Worker dbarchiver finished and data correct, source data count is 6, target data count is 6
+INFO[0001] Worker bendarchiver finished and data correct, source data count is 6, target data count is 6
 end time: 2025-01-22 21:45:34
 total time: 1.269478875s
 ```

--- a/docs/en/tutorials/index.md
+++ b/docs/en/tutorials/index.md
@@ -26,7 +26,7 @@ Pick a task to get started:
 - [How to choose a MySQL migration path](/tutorials/migrate/)
 - [MySQL CDC with Debezium](/tutorials/migrate/migrating-from-mysql-with-debezium)
 - [MySQL CDC with Flink](/tutorials/migrate/migrating-from-mysql-with-flink-cdc)
-- [MySQL batch: db-archiver / DataX / Addax](/tutorials/migrate/migrating-from-mysql-with-db-archiver)
+- [MySQL batch: bend-archiver / DataX / Addax](/tutorials/migrate/migrating-from-mysql-with-db-archiver)
 - [Snowflake to Databend](/tutorials/migrate/migrating-from-snowflake)
 
 ## Develop with Databend

--- a/docs/en/tutorials/migrate/index.md
+++ b/docs/en/tutorials/migrate/index.md
@@ -12,7 +12,7 @@ Databend supports two main migration approaches from MySQL:
 
 | Migration Approach       | Recommended Tool             | Supported MySQL versions |
 |--------------------------|------------------------------|--------------------------|
-| Batch Loading            | db-archiver                  | All MySQL versions       |
+| Batch Loading            | bend-archiver                | All MySQL versions       |
 | Continuous Sync with CDC | Debezium                     | All MySQL versions       |
 
 ### When to Choose Real-time Migration (CDC)
@@ -30,7 +30,7 @@ Databend supports two main migration approaches from MySQL:
 
 ### When to Choose Batch Migration
 
-> **Recommendation**: For batch migration, we recommend **db-archiver** as the default choice.
+> **Recommendation**: For batch migration, we recommend **bend-archiver** as the default choice.
 
 - You need one-time or scheduled data transfers
 - You have large volumes of historical data to migrate
@@ -38,7 +38,7 @@ Databend supports two main migration approaches from MySQL:
 
 | Tool | Capabilities | Best For | Choose When |
 |------|------------|----------|-------------|
-| [db-archiver](/tutorials/migrate/migrating-from-mysql-with-db-archiver) | Full Load, Incremental | Efficient historical data archiving | You have time-partitioned data; You need to archive historical data; You want a lightweight, focused tool |
+| [bend-archiver](/tutorials/migrate/migrating-from-mysql-with-db-archiver) | Full Load, Incremental | Efficient historical data archiving | You have time-partitioned data; You need to archive historical data; You want a lightweight, focused tool |
 | [DataX](/tutorials/migrate/migrating-from-mysql-with-datax) | Full Load, Incremental | High-performance large dataset transfers | You need high throughput for large datasets; You want parallel processing capabilities; You need a mature, widely-used tool |
 | [Addax](/tutorials/migrate/migrating-from-mysql-with-addax) | Full Load, Incremental | Enhanced DataX with better performance | You need better error handling than DataX; You want improved monitoring capabilities; You need more recent updates and features |
 

--- a/docs/en/tutorials/migrate/migrating-from-mysql-with-db-archiver.md
+++ b/docs/en/tutorials/migrate/migrating-from-mysql-with-db-archiver.md
@@ -1,19 +1,19 @@
 ---
-title: Migrate MySQL with db-archiver (Batch)
-sidebar_label: 'MySQL → Databend: db-archiver (Batch)'
+title: Migrate MySQL with bend-archiver (Batch)
+sidebar_label: 'MySQL → Databend: bend-archiver (Batch)'
 ---
 
 > **Capabilities**: Full Load, Incremental  
 > **✅ Recommended** for batch migration of historical data
 
-In this tutorial, we'll walk you through the process of migrating from MySQL to Databend Cloud using db-archiver.
+In this tutorial, we'll walk you through the process of migrating from MySQL to Databend Cloud using bend-archiver.
 
 ## Before You Start
 
 Before you start, ensure you have the following prerequisites in place:
 
 - [Docker](https://www.docker.com/) is installed on your local machine, as it will be used to launch MySQL.
-- [Go](https://go.dev/dl/) is installed on your local machine, as it is required to install db-archiver.
+- [Go](https://go.dev/dl/) is installed on your local machine, as it is required to install bend-archiver.
 - BendSQL is installed on your local machine. See [Installing BendSQL](/guides/connect/sql-clients/bendsql/#installing-bendsql) for instructions on how to install BendSQL using various package managers.
 
 ## Step 1: Launch MySQL in Docker
@@ -120,11 +120,11 @@ CREATE TABLE my_table (
 );
 ```
 
-## Step 4: Install db-archiver
+## Step 4: Install bend-archiver
 
-Download the db-archiver from the [release page](https://github.com/databendcloud/db-archiver/releases/) according to your arch.
+Download bend-archiver from the [release page](https://github.com/databendlabs/bend-archiver/releases/) according to your arch.
 
-## Step 5: Configure & Run db-archiver
+## Step 5: Configure & Run bend-archiver
 
 1. Create a file named **conf.json** on your local machine with the following content:
 
@@ -155,7 +155,7 @@ Download the db-archiver from the [release page](https://github.com/databendclou
 2. Run the following command in the directory where your **conf.json** file is located to start the migration:
 
 ```bash
-db-archiver -f conf.json
+bend-archiver -f conf.json
 ```
 
 Migration will begin as follows:
@@ -195,7 +195,7 @@ INFO[0001] thread-1: copy into cost: 407 ms              ingest_databend=IngestD
 INFO[0001] thread-1: copy into cost: 475 ms              ingest_databend=IngestData
 2025/01/22 21:45:34 thread-1: ingest 2 rows (2.401148 rows/s), 70 bytes (81.639015 bytes/s)
 2025/01/22 21:45:34 Globla speed: total ingested 6 rows (2.400957 rows/s), 93 bytes (34.813873 bytes/s)
-INFO[0001] Worker dbarchiver finished and data correct, source data count is 6, target data count is 6
+INFO[0001] Worker bendarchiver finished and data correct, source data count is 6, target data count is 6
 end time: 2025-01-22 21:45:34
 total time: 1.269478875s
 ```


### PR DESCRIPTION
What changed
- Rename db-archiver to bend-archiver in EN/CN migration docs and indexes
- Update release URL to databendlabs/bend-archiver

Why
- Project renamed to bend-archiver

Testing
- Not run (docs-only)