### PR TITLE
docs: add PARTITION BY for COPY INTO <location>

### DIFF
--- a/docs/en/sql-reference/10-sql-commands/10-dml/dml-copy-into-location.md
+++ b/docs/en/sql-reference/10-sql-commands/10-dml/dml-copy-into-location.md
@@ -329,9 +329,11 @@ INSERT INTO sales_data VALUES
 CREATE STAGE partitioned_stage;
 
 -- Unload data partitioned by year-month derived from sale_date
+-- When sale_date is NULL, to_varchar() returns NULL, so the entire
+-- concatenation evaluates to NULL and the row lands in the _NULL_ folder.
 COPY INTO @partitioned_stage
     FROM sales_data
-    PARTITION BY ('month=' || COALESCE(to_varchar(sale_date, 'YYYY-MM'), 'unknown'))
+    PARTITION BY ('month=' || to_varchar(sale_date, 'YYYY-MM'))
     FILE_FORMAT = (TYPE = PARQUET);
 
 -- Verify the partitioned folder layout


### PR DESCRIPTION
## Summary

Documentation update for databendlabs/databend#19390.

- Added `PARTITION BY ( <expr> )` clause to the COPY INTO `<location>` syntax block
- Added a new "PARTITION BY" section explaining the expression semantics, NULL handling (`_NULL_` folder), and incompatible options (SINGLE, OVERWRITE, INCLUDE_QUERY_ID)
- Added Example 4 demonstrating partitioned unloading with folder layout verification
- Updated `FunctionDescription` version tag to v1.2.881

## Related

- Source PR: https://github.com/databendlabs/databend/pull/19390