### PR TITLE
fix: add cleanUrls and trailingSlash to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "cleanUrls": true,
+  "trailingSlash": false,
   "rewrites": [
     {
       "source": "/",


### PR DESCRIPTION
With `trailingSlash: false` in Docusaurus, build output generates `page.html` files instead of `page/index.html`. Vercel needs `cleanUrls: true` to serve `/page` → `page.html`, and `trailingSlash: false` to redirect `/page/` → `/page`.

Without this fix, all pages return 404 on Vercel.