### PR TITLE
docs: update CREATE/ALTER DATABASE with OPTIONS clause (v1.2.866)

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/00-database/ddl-alter-database.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/00-database/ddl-alter-database.md
@@ -1,17 +1,42 @@
 ---
-title: RENAME DATABASE
+title: ALTER DATABASE
 sidebar_position: 4
 ---
 
-更改数据库的名称。
+import FunctionDescription from '@site/src/components/FunctionDescription';
 
-## 句法
+<FunctionDescription description="引入或更新于：v1.2.866"/>
+
+更改数据库的名称，或为数据库设置默认存储选项。
+
+## 语法
 
 ```sql
+-- 重命名数据库
 ALTER DATABASE [ IF EXISTS ] <name> RENAME TO <new_db_name>
+
+-- 设置默认存储选项
+ALTER DATABASE [ IF EXISTS ] <name> SET OPTIONS (
+    DEFAULT_STORAGE_CONNECTION = '<connection_name>'
+  | DEFAULT_STORAGE_PATH = '<path>'
+)
 ```
 
+## 参数
+
+| 参数                          | 描述                                                                                                                          |
+|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------|
+| `DEFAULT_STORAGE_CONNECTION` | 已有连接的名称（通过 `CREATE CONNECTION` 创建），作为该数据库中表的默认存储连接。                                               |
+| `DEFAULT_STORAGE_PATH`       | 该数据库中表的默认存储路径 URI（如 `s3://bucket/path/`），必须以 `/` 结尾，且与连接的存储类型匹配。                            |
+
+:::note
+- `SET OPTIONS` 只对执行该语句后新建的表生效，已有表不受影响。
+- 每次可以单独更新一个选项，但前提是另一个选项已在该数据库上设置。
+:::
+
 ## 示例
+
+### 重命名数据库
 
 ```sql
 CREATE DATABASE DATABEND;
@@ -43,4 +68,13 @@ SHOW DATABASES;
 | default            |
 | system             |
 +--------------------+
+```
+
+### 设置默认存储选项
+
+```sql
+ALTER DATABASE analytics SET OPTIONS (
+    DEFAULT_STORAGE_CONNECTION = 'my_s3',
+    DEFAULT_STORAGE_PATH = 's3://mybucket/analytics_v2/'
+);
 ```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/00-database/ddl-create-database.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/00-database/ddl-create-database.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="引入或更新于：v1.2.339"/>
+<FunctionDescription description="引入或更新于：v1.2.866"/>
 
 创建数据库。
 
@@ -13,7 +13,23 @@ import FunctionDescription from '@site/src/components/FunctionDescription';
 
 ```sql
 CREATE [ OR REPLACE ] DATABASE [ IF NOT EXISTS ] <database_name>
+    [ OPTIONS (
+        DEFAULT_STORAGE_CONNECTION = '<connection_name>',
+        DEFAULT_STORAGE_PATH = '<path>'
+    ) ]
 ```
+
+## 参数
+
+| 参数                           | 描述                                                                                                                          |
+|:------------------------------|:------------------------------------------------------------------------------------------------------------------------------|
+| `DEFAULT_STORAGE_CONNECTION`  | 已有连接的名称（通过 `CREATE CONNECTION` 创建），作为该数据库中表的默认存储连接。                                               |
+| `DEFAULT_STORAGE_PATH`        | 该数据库中表的默认存储路径 URI（如 `s3://bucket/path/`），必须以 `/` 结尾，且与连接的存储类型匹配。                            |
+
+:::note
+- `DEFAULT_STORAGE_CONNECTION` 与 `DEFAULT_STORAGE_PATH` 必须同时指定，单独指定其中一个会报错。
+- 两个选项均设置时，Databend 会验证连接是否存在、路径 URI 格式是否正确，以及存储位置是否可访问。
+:::
 
 ## 访问控制要求
 
@@ -29,4 +45,15 @@ CREATE [ OR REPLACE ] DATABASE [ IF NOT EXISTS ] <database_name>
 
 ```sql
 CREATE DATABASE test;
+```
+
+以下示例创建一个指定默认存储连接和路径的数据库：
+
+```sql
+CREATE CONNECTION my_s3 STORAGE_TYPE = 's3' ACCESS_KEY_ID = '<key>' SECRET_ACCESS_KEY = '<secret>';
+
+CREATE DATABASE analytics OPTIONS (
+    DEFAULT_STORAGE_CONNECTION = 'my_s3',
+    DEFAULT_STORAGE_PATH = 's3://mybucket/analytics/'
+);
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/00-database/ddl-alter-database.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/00-database/ddl-alter-database.md
@@ -1,17 +1,42 @@
 ---
-title: RENAME DATABASE
+title: ALTER DATABASE
 sidebar_position: 4
 ---
 
-Changes the name of a database.
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.866"/>
+
+Changes the name of a database, or sets default storage options for a database.
 
 ## Syntax
 
 ```sql
+-- Rename a database
 ALTER DATABASE [ IF EXISTS ] <name> RENAME TO <new_db_name>
+
+-- Set default storage options
+ALTER DATABASE [ IF EXISTS ] <name> SET OPTIONS (
+    DEFAULT_STORAGE_CONNECTION = '<connection_name>'
+  | DEFAULT_STORAGE_PATH = '<path>'
+)
 ```
 
+## Parameters
+
+| Parameter                    | Description                                                                                                                                      |
+|:-----------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DEFAULT_STORAGE_CONNECTION` | The name of an existing connection (created via `CREATE CONNECTION`) to use as the default storage connection for tables in this database.        |
+| `DEFAULT_STORAGE_PATH`       | The default storage path URI (e.g., `s3://bucket/path/`) for tables in this database. Must end with `/` and match the connection's storage type. |
+
+:::note
+- `SET OPTIONS` only affects tables created after the statement is executed. Existing tables are not changed.
+- You can update one option at a time, as long as the other option already exists on the database.
+:::
+
 ## Examples
+
+### Rename a database
 
 ```sql
 CREATE DATABASE DATABEND;
@@ -43,4 +68,13 @@ SHOW DATABASES;
 | default            |
 | system             |
 +--------------------+
+```
+
+### Set default storage options
+
+```sql
+ALTER DATABASE analytics SET OPTIONS (
+    DEFAULT_STORAGE_CONNECTION = 'my_s3',
+    DEFAULT_STORAGE_PATH = 's3://mybucket/analytics_v2/'
+);
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/00-database/ddl-create-database.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/00-database/ddl-create-database.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: v1.2.339"/>
+<FunctionDescription description="Introduced or updated: v1.2.866"/>
 
 Create a database.
 
@@ -13,7 +13,23 @@ Create a database.
 
 ```sql
 CREATE [ OR REPLACE ] DATABASE [ IF NOT EXISTS ] <database_name>
+    [ OPTIONS (
+        DEFAULT_STORAGE_CONNECTION = '<connection_name>',
+        DEFAULT_STORAGE_PATH = '<path>'
+    ) ]
 ```
+
+## Parameters
+
+| Parameter                    | Description                                                                                                                                      |
+|:-----------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DEFAULT_STORAGE_CONNECTION` | The name of an existing connection (created via `CREATE CONNECTION`) to use as the default storage connection for tables in this database.        |
+| `DEFAULT_STORAGE_PATH`       | The default storage path URI (e.g., `s3://bucket/path/`) for tables in this database. Must end with `/` and match the connection's storage type. |
+
+:::note
+- `DEFAULT_STORAGE_CONNECTION` and `DEFAULT_STORAGE_PATH` must be specified together. Specifying only one is an error.
+- When both options are set, Databend validates that the connection exists, the path URI is well-formed, and the storage location is accessible.
+:::
 
 ## Access control requirements
 
@@ -30,4 +46,15 @@ The following example creates a database named `test`:
 
 ```sql
 CREATE DATABASE test;
+```
+
+The following example creates a database with a default storage connection and path:
+
+```sql
+CREATE CONNECTION my_s3 STORAGE_TYPE = 's3' ACCESS_KEY_ID = '<key>' SECRET_ACCESS_KEY = '<secret>';
+
+CREATE DATABASE analytics OPTIONS (
+    DEFAULT_STORAGE_CONNECTION = 'my_s3',
+    DEFAULT_STORAGE_PATH = 's3://mybucket/analytics/'
+);
 ```


### PR DESCRIPTION
## Summary

Update CREATE DATABASE and ALTER DATABASE documentation to reflect the new OPTIONS clause introduced in databendlabs/databend#18886.

## Changes

- **CREATE DATABASE**: Add `OPTIONS` syntax with `DEFAULT_STORAGE_CONNECTION` and `DEFAULT_STORAGE_PATH` parameters, constraints, and examples
- **ALTER DATABASE**: Add `SET OPTIONS` syntax with note that changes only affect newly created tables

Both English and Chinese docs updated.