### PR TITLE
docs: add worker SQL reference

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/_category_.json
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "工作节点（Worker）",
+  "position": 20
+}

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/alter-worker.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/alter-worker.md
@@ -1,0 +1,67 @@
+---
+title: ALTER WORKER
+sidebar_position: 2
+---
+
+修改 worker 的标签、选项或运行状态。
+
+:::note
+此命令需要启用 cloud control。
+:::
+
+## 语法
+
+```sql
+ALTER WORKER <worker_name> SET TAG <tag_name> = '<tag_value>' [ , <tag_name> = '<tag_value>' , ... ]
+
+ALTER WORKER <worker_name> UNSET TAG <tag_name> [ , <tag_name> , ... ]
+
+ALTER WORKER <worker_name> SET <option_name> = '<option_value>' [ , <option_name> = '<option_value>' , ... ]
+
+ALTER WORKER <worker_name> UNSET <option_name> [ , <option_name> , ... ]
+
+ALTER WORKER <worker_name> SUSPEND
+
+ALTER WORKER <worker_name> RESUME
+```
+
+## 参数
+
+| 形式 | 说明 |
+|------|-------------|
+| `SET TAG` | 添加或更新 worker 标签。 |
+| `UNSET TAG` | 删除一个或多个 worker 标签。 |
+| `SET` | 添加或更新 worker 选项。选项名会被规范化为小写。 |
+| `UNSET` | 删除一个或多个 worker 选项。 |
+| `SUSPEND` | 挂起 worker。 |
+| `RESUME` | 恢复 worker。 |
+
+## 示例
+
+为 worker 设置标签：
+
+```sql
+ALTER WORKER ingest_worker
+SET TAG environment = 'prod', team = 'data-platform';
+```
+
+更新 worker 选项：
+
+```sql
+ALTER WORKER ingest_worker
+SET region = 'us-west-2', pool = 'streaming';
+```
+
+删除标签和选项：
+
+```sql
+ALTER WORKER ingest_worker UNSET TAG team;
+ALTER WORKER ingest_worker UNSET pool;
+```
+
+修改 worker 状态：
+
+```sql
+ALTER WORKER ingest_worker SUSPEND;
+ALTER WORKER ingest_worker RESUME;
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/create-worker.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/create-worker.md
@@ -1,0 +1,40 @@
+---
+title: CREATE WORKER
+sidebar_position: 1
+---
+
+创建一个 worker。
+
+:::note
+此命令需要启用 cloud control。
+:::
+
+## 语法
+
+```sql
+CREATE WORKER [ IF NOT EXISTS ] <worker_name>
+    [ WITH <option_name> = '<option_value>' [ , <option_name> = '<option_value>' , ... ] ]
+```
+
+## 参数
+
+| 参数 | 说明 |
+|-----------|-------------|
+| `IF NOT EXISTS` | 可选。如果 worker 已存在，则成功返回但不做修改。 |
+| `<worker_name>` | worker 名称。 |
+| `WITH ...` | 可选的逗号分隔键值选项列表。选项名会被规范化为小写。 |
+
+## 示例
+
+创建一个不带选项的 worker：
+
+```sql
+CREATE WORKER ingest_worker;
+```
+
+创建一个带自定义选项的 worker：
+
+```sql
+CREATE WORKER IF NOT EXISTS ingest_worker
+WITH region = 'us-east-1', pool = 'etl';
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/drop-worker.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/drop-worker.md
@@ -1,0 +1,33 @@
+---
+title: DROP WORKER
+sidebar_position: 3
+---
+
+删除一个 worker。
+
+:::note
+此命令需要启用 cloud control。
+:::
+
+## 语法
+
+```sql
+DROP WORKER [ IF EXISTS ] <worker_name>
+```
+
+## 参数
+
+| 参数 | 说明 |
+|-----------|-------------|
+| `IF EXISTS` | 可选。如果 worker 不存在，则忽略错误。 |
+| `<worker_name>` | worker 名称。 |
+
+## 示例
+
+```sql
+DROP WORKER ingest_worker;
+```
+
+```sql
+DROP WORKER IF EXISTS ingest_worker;
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/index.md
@@ -1,0 +1,33 @@
+---
+title: 工作节点（Worker）
+---
+
+适用于启用了 cloud control 的部署的 Worker 相关 SQL 命令。
+
+:::note
+Worker 管理命令依赖 cloud control。如果未配置 `cloud_control_grpc_server_address`，执行这些命令时 Databend 会返回 `CloudControlNotEnabled` 错误。
+:::
+
+## 支持的语句
+
+| 语句 | 用途 |
+|-----------|---------|
+| `CREATE WORKER` | 创建 worker，并可附带键值形式的选项 |
+| `ALTER WORKER` | 更新 worker 的标签、选项或运行状态 |
+| `DROP WORKER` | 删除 worker |
+| `SHOW WORKERS` | 列出当前 tenant 下的 worker |
+
+## 命令参考
+
+| 命令 | 描述 |
+|---------|-------------|
+| [CREATE WORKER](create-worker.md) | 创建 worker 定义 |
+| [ALTER WORKER](alter-worker.md) | 修改 worker 的标签、选项或状态 |
+| [DROP WORKER](drop-worker.md) | 删除 worker 定义 |
+| [SHOW WORKERS](show-workers.md) | 查看 worker 及其元数据 |
+
+## 说明
+
+- 选项名不区分大小写，Databend 在规划阶段会将它们规范化为小写。
+- `SHOW WORKERS` 返回 `name`、`tags`、`options`、`created_at` 和 `updated_at` 列。
+- `ALTER WORKER` 支持 `SET TAG`、`UNSET TAG`、`SET`、`UNSET`、`SUSPEND` 和 `RESUME`。

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/show-workers.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/20-worker/show-workers.md
@@ -1,0 +1,34 @@
+---
+title: SHOW WORKERS
+sidebar_position: 4
+---
+
+列出当前 tenant 下的 worker。
+
+:::note
+此命令需要启用 cloud control。
+:::
+
+## 语法
+
+```sql
+SHOW WORKERS
+```
+
+## 输出
+
+`SHOW WORKERS` 返回以下列：
+
+| 列名 | 说明 |
+|--------|-------------|
+| `name` | worker 名称 |
+| `tags` | JSON 格式的 worker 标签 |
+| `options` | JSON 格式的 worker 选项 |
+| `created_at` | worker 创建时间 |
+| `updated_at` | worker 更新时间 |
+
+## 示例
+
+```sql
+SHOW WORKERS;
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
@@ -58,6 +58,7 @@ title: DDL（Data Definition Language）命令
 | 组件 | 描述 |
 |-----------|-------------|
 | **[计算集群 (Warehouse)](19-warehouse/index.md)** | 管理用于查询执行的计算资源 |
+| **[工作节点 (Worker)](20-worker/index.md)** | 通过 cloud control 管理 worker 资源 |
 | **[工作负载组 (Workload Group)](20-workload-group/index.md)** | 控制资源分配和优先级 |
 | **[事务 (Transaction)](14-transaction/index.md)** | 管理数据库事务 |
 | **[变量 (Variable)](15-variable/index.md)** | 设置和使用会话/全局变量 |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/_category_.json
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Worker",
+  "position": 20
+}

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/alter-worker.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/alter-worker.md
@@ -1,0 +1,67 @@
+---
+title: ALTER WORKER
+sidebar_position: 2
+---
+
+Modifies a worker's tags, options, or state.
+
+:::note
+This command requires cloud control to be enabled.
+:::
+
+## Syntax
+
+```sql
+ALTER WORKER <worker_name> SET TAG <tag_name> = '<tag_value>' [ , <tag_name> = '<tag_value>' , ... ]
+
+ALTER WORKER <worker_name> UNSET TAG <tag_name> [ , <tag_name> , ... ]
+
+ALTER WORKER <worker_name> SET <option_name> = '<option_value>' [ , <option_name> = '<option_value>' , ... ]
+
+ALTER WORKER <worker_name> UNSET <option_name> [ , <option_name> , ... ]
+
+ALTER WORKER <worker_name> SUSPEND
+
+ALTER WORKER <worker_name> RESUME
+```
+
+## Parameters
+
+| Form | Description |
+|------|-------------|
+| `SET TAG` | Adds or updates worker tags. |
+| `UNSET TAG` | Removes one or more worker tags. |
+| `SET` | Adds or updates worker options. Option names are normalized to lowercase. |
+| `UNSET` | Removes one or more worker options. |
+| `SUSPEND` | Suspends the worker. |
+| `RESUME` | Resumes the worker. |
+
+## Examples
+
+Set tags on a worker:
+
+```sql
+ALTER WORKER ingest_worker
+SET TAG environment = 'prod', team = 'data-platform';
+```
+
+Update worker options:
+
+```sql
+ALTER WORKER ingest_worker
+SET region = 'us-west-2', pool = 'streaming';
+```
+
+Remove a tag and an option:
+
+```sql
+ALTER WORKER ingest_worker UNSET TAG team;
+ALTER WORKER ingest_worker UNSET pool;
+```
+
+Change worker state:
+
+```sql
+ALTER WORKER ingest_worker SUSPEND;
+ALTER WORKER ingest_worker RESUME;
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/create-worker.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/create-worker.md
@@ -1,0 +1,40 @@
+---
+title: CREATE WORKER
+sidebar_position: 1
+---
+
+Creates a worker.
+
+:::note
+This command requires cloud control to be enabled.
+:::
+
+## Syntax
+
+```sql
+CREATE WORKER [ IF NOT EXISTS ] <worker_name>
+    [ WITH <option_name> = '<option_value>' [ , <option_name> = '<option_value>' , ... ] ]
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `IF NOT EXISTS` | Optional. Succeeds without changes if the worker already exists. |
+| `<worker_name>` | The worker name. |
+| `WITH ...` | Optional comma-separated key-value options. Option names are normalized to lowercase. |
+
+## Examples
+
+Create a worker without options:
+
+```sql
+CREATE WORKER ingest_worker;
+```
+
+Create a worker with custom options:
+
+```sql
+CREATE WORKER IF NOT EXISTS ingest_worker
+WITH region = 'us-east-1', pool = 'etl';
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/drop-worker.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/drop-worker.md
@@ -1,0 +1,33 @@
+---
+title: DROP WORKER
+sidebar_position: 3
+---
+
+Removes a worker.
+
+:::note
+This command requires cloud control to be enabled.
+:::
+
+## Syntax
+
+```sql
+DROP WORKER [ IF EXISTS ] <worker_name>
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `IF EXISTS` | Optional. Suppresses the error if the worker does not exist. |
+| `<worker_name>` | The worker name. |
+
+## Examples
+
+```sql
+DROP WORKER ingest_worker;
+```
+
+```sql
+DROP WORKER IF EXISTS ingest_worker;
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/index.md
@@ -1,0 +1,33 @@
+---
+title: Worker
+---
+
+Worker-related SQL commands for deployments with cloud control enabled.
+
+:::note
+Worker management commands require cloud control. If `cloud_control_grpc_server_address` is not configured, Databend returns a `CloudControlNotEnabled` error when you run these commands.
+:::
+
+## Supported Statements
+
+| Statement | Purpose |
+|-----------|---------|
+| `CREATE WORKER` | Creates a worker with an optional key-value option list |
+| `ALTER WORKER` | Updates worker tags or options, or changes worker state |
+| `DROP WORKER` | Deletes a worker |
+| `SHOW WORKERS` | Lists workers in the current tenant |
+
+## Command Reference
+
+| Command | Description |
+|---------|-------------|
+| [CREATE WORKER](create-worker.md) | Creates a worker definition |
+| [ALTER WORKER](alter-worker.md) | Modifies worker tags, options, or state |
+| [DROP WORKER](drop-worker.md) | Removes a worker definition |
+| [SHOW WORKERS](show-workers.md) | Lists workers and their metadata |
+
+## Notes
+
+- Option names are case-insensitive. Databend normalizes them to lowercase during planning.
+- `SHOW WORKERS` returns the columns `name`, `tags`, `options`, `created_at`, and `updated_at`.
+- `ALTER WORKER` supports `SET TAG`, `UNSET TAG`, `SET`, `UNSET`, `SUSPEND`, and `RESUME`.

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/show-workers.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/20-worker/show-workers.md
@@ -1,0 +1,34 @@
+---
+title: SHOW WORKERS
+sidebar_position: 4
+---
+
+Lists workers in the current tenant.
+
+:::note
+This command requires cloud control to be enabled.
+:::
+
+## Syntax
+
+```sql
+SHOW WORKERS
+```
+
+## Output
+
+`SHOW WORKERS` returns the following columns:
+
+| Column | Description |
+|--------|-------------|
+| `name` | Worker name |
+| `tags` | Worker tags in JSON format |
+| `options` | Worker options in JSON format |
+| `created_at` | Worker creation timestamp |
+| `updated_at` | Worker update timestamp |
+
+## Examples
+
+```sql
+SHOW WORKERS;
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
@@ -58,6 +58,7 @@ These topics provide reference information for the DDL (Data Definition Language
 | Component | Description |
 |-----------|-------------|
 | **[Warehouse](19-warehouse/index.md)** | Manage compute resources for query execution |
+| **[Worker](20-worker/index.md)** | Manage worker resources through cloud control |
 | **[Workload Group](20-workload-group/index.md)** | Control resource allocation and priorities |
 | **[Transaction](14-transaction/index.md)** | Manage database transactions |
 | **[Variable](15-variable/index.md)** | Set and use session/global variables |


### PR DESCRIPTION
## Summary
- add a new DDL Worker section under SQL Reference
- document CREATE WORKER, ALTER WORKER, DROP WORKER, and SHOW WORKERS
- link the new Worker section from the DDL overview

## Why
`WORKER` SQL is implemented in Databend today, but the docs site did not have dedicated SQL reference pages for it.

## Verification
- checked the current Databend parser, binder, planner schema, and interpreters for worker statements
- ran `git diff --check`
- did not run a docs build locally because `/workspace/databend-docs/node_modules` is not installed in this environment