### PR TITLE
docs: add CREATE DICTIONARY SQL reference

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/_category_.json
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "字典（Dictionary）",
+  "position": 17
+}

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/create-dictionary.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/create-dictionary.md
@@ -1,0 +1,57 @@
+---
+title: CREATE DICTIONARY
+sidebar_position: 1
+---
+
+创建一个外部字典。
+
+## 语法
+
+```sql
+CREATE [ OR REPLACE ] DICTIONARY [ IF NOT EXISTS ] [ <catalog_name>. ][ <database_name>. ]<dictionary_name>
+(
+    <column_name> <data_type> [ , <column_name> <data_type> , ... ]
+)
+PRIMARY KEY <column_name> [ , <column_name> , ... ]
+SOURCE(
+    <source_name>(
+        <source_option> = '<value>' [ <source_option> = '<value>' ... ]
+    )
+)
+[ COMMENT '<comment>' ]
+```
+
+## 参数
+
+| 参数 | 说明 |
+|-----------|-------------|
+| `OR REPLACE` | 如果同名字典已存在，则替换它。 |
+| `IF NOT EXISTS` | 如果字典已存在，则成功返回但不做修改。 |
+| `<dictionary_name>` | 字典名称。可以带上 catalog 和 database 限定。 |
+| `(<column_name> <data_type>, ...)` | 定义字典的列结构。 |
+| `PRIMARY KEY` | 定义一个或多个用于字典查找的主键列。 |
+| `SOURCE(...)` | 定义数据源连接器名称及其键值参数。 |
+| `COMMENT` | 可选的字典备注。 |
+
+## 示例
+
+```sql
+CREATE DICTIONARY user_info
+(
+    user_id UInt64,
+    user_name String,
+    user_email String
+)
+PRIMARY KEY user_id
+SOURCE(
+    mysql(
+        host = '127.0.0.1'
+        port = '3306'
+        username = 'root'
+        password = 'root'
+        db = 'app'
+        table = 'users'
+    )
+)
+COMMENT '来自 MySQL 的用户字典';
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/create-dictionary.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/create-dictionary.md
@@ -3,7 +3,7 @@ title: CREATE DICTIONARY
 sidebar_position: 1
 ---
 
-创建一个外部字典。
+创建一个字典。
 
 ## 语法
 
@@ -33,7 +33,13 @@ SOURCE(
 | `SOURCE(...)` | 定义数据源连接器名称及其键值参数。 |
 | `COMMENT` | 可选的字典备注。 |
 
+:::note
+- SOURCE 仅支持 `MySQL` 和 `Redis`。
+:::
+
 ## 示例
+
+MySQL 示例：
 
 ```sql
 CREATE DICTIONARY user_info
@@ -53,5 +59,23 @@ SOURCE(
         table = 'users'
     )
 )
-COMMENT '来自 MySQL 的用户字典';
+COMMENT 'User dictionary from MySQL';
+```
+
+Redis 示例：
+
+```sql
+CREATE DICTIONARY cache
+(
+    key String,
+    value String
+)
+PRIMARY KEY key
+SOURCE(
+    redis(
+        host = '127.0.0.1'
+        port = '6379'
+    )
+)
+COMMENT 'cache dictionary from Redis';
 ```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/index.md
@@ -2,16 +2,10 @@
 title: 字典（Dictionary）
 ---
 
-Databend 中外部字典相关的 SQL 命令。
+Dictionary 提供了一种基于键值对的方法，用于从各种外部数据源（包括 MySQL 和 Redis）读取数据。
 
-## 支持的语句
-
-| 语句 | 用途 |
-|-----------|---------|
-| `CREATE DICTIONARY` | 创建由外部数据源驱动的外部字典 |
-
-## 命令参考
+## 字典管理
 
 | 命令 | 描述 |
 |---------|-------------|
-| [CREATE DICTIONARY](create-dictionary.md) | 创建外部字典 |
+| [CREATE DICTIONARY](create-dictionary.md) | 创建字典 |

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/17-dictionary/index.md
@@ -1,0 +1,17 @@
+---
+title: 字典（Dictionary）
+---
+
+Databend 中外部字典相关的 SQL 命令。
+
+## 支持的语句
+
+| 语句 | 用途 |
+|-----------|---------|
+| `CREATE DICTIONARY` | 创建由外部数据源驱动的外部字典 |
+
+## 命令参考
+
+| 命令 | 描述 |
+|---------|-------------|
+| [CREATE DICTIONARY](create-dictionary.md) | 创建外部字典 |

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
@@ -41,6 +41,7 @@ title: DDL（Data Definition Language）命令
 | **[流 (Stream)](04-stream/index.md)** | 捕获和处理数据变更 |
 | **[任务 (Task)](04-task/index.md)** | 调度和自动化 SQL 操作 |
 | **[序列 (Sequence)](04-sequence/index.md)** | 生成唯一的序列号 |
+| **[字典 (Dictionary)](17-dictionary/index.md)** | 定义由外部数据源驱动的外部字典 |
 | **[连接 (Connection)](13-connection/index.md)** | 配置外部数据源连接 |
 | **[文件格式 (File Format)](13-file-format/index.md)** | 为数据导入/导出定义格式 |
 

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
@@ -41,9 +41,9 @@ title: DDL（Data Definition Language）命令
 | **[流 (Stream)](04-stream/index.md)** | 捕获和处理数据变更 |
 | **[任务 (Task)](04-task/index.md)** | 调度和自动化 SQL 操作 |
 | **[序列 (Sequence)](04-sequence/index.md)** | 生成唯一的序列号 |
-| **[字典 (Dictionary)](17-dictionary/index.md)** | 定义由外部数据源驱动的外部字典 |
 | **[连接 (Connection)](13-connection/index.md)** | 配置外部数据源连接 |
 | **[文件格式 (File Format)](13-file-format/index.md)** | 为数据导入/导出定义格式 |
+| **[字典 (Dictionary)](17-dictionary/index.md)** | 定义由外部数据源驱动的字典 |
 
 ## 函数和存储过程
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/_category_.json
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Dictionary",
+  "position": 17
+}

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/create-dictionary.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/create-dictionary.md
@@ -1,0 +1,57 @@
+---
+title: CREATE DICTIONARY
+sidebar_position: 1
+---
+
+Creates an external dictionary.
+
+## Syntax
+
+```sql
+CREATE [ OR REPLACE ] DICTIONARY [ IF NOT EXISTS ] [ <catalog_name>. ][ <database_name>. ]<dictionary_name>
+(
+    <column_name> <data_type> [ , <column_name> <data_type> , ... ]
+)
+PRIMARY KEY <column_name> [ , <column_name> , ... ]
+SOURCE(
+    <source_name>(
+        <source_option> = '<value>' [ <source_option> = '<value>' ... ]
+    )
+)
+[ COMMENT '<comment>' ]
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `OR REPLACE` | Replaces an existing dictionary with the same name. |
+| `IF NOT EXISTS` | Succeeds without changes if the dictionary already exists. |
+| `<dictionary_name>` | The dictionary name. You can qualify it with catalog and database names. |
+| `(<column_name> <data_type>, ...)` | Declares the dictionary schema. |
+| `PRIMARY KEY` | Defines one or more key columns used for dictionary lookups. |
+| `SOURCE(...)` | Defines the source connector name and its key-value options. |
+| `COMMENT` | Optional dictionary comment. |
+
+## Examples
+
+```sql
+CREATE DICTIONARY user_info
+(
+    user_id UInt64,
+    user_name String,
+    user_email String
+)
+PRIMARY KEY user_id
+SOURCE(
+    mysql(
+        host = '127.0.0.1'
+        port = '3306'
+        username = 'root'
+        password = 'root'
+        db = 'app'
+        table = 'users'
+    )
+)
+COMMENT 'User dictionary from MySQL';
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/create-dictionary.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/create-dictionary.md
@@ -3,7 +3,7 @@ title: CREATE DICTIONARY
 sidebar_position: 1
 ---
 
-Creates an external dictionary.
+Creates a dictionary.
 
 ## Syntax
 
@@ -33,7 +33,13 @@ SOURCE(
 | `SOURCE(...)` | Defines the source connector name and its key-value options. |
 | `COMMENT` | Optional dictionary comment. |
 
+:::note
+- SOURCE only support `MySQL` and `Redis`.
+:::
+
 ## Examples
+
+MySQL example:
 
 ```sql
 CREATE DICTIONARY user_info
@@ -54,4 +60,22 @@ SOURCE(
     )
 )
 COMMENT 'User dictionary from MySQL';
+```
+
+Redis example:
+
+```sql
+CREATE DICTIONARY cache
+(
+    key String,
+    value String
+)
+PRIMARY KEY key
+SOURCE(
+    redis(
+        host = '127.0.0.1'
+        port = '6379'
+    )
+)
+COMMENT 'cache dictionary from Redis';
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/index.md
@@ -1,0 +1,17 @@
+---
+title: Dictionary
+---
+
+Dictionary-related SQL commands for external dictionaries in Databend.
+
+## Supported Statements
+
+| Statement | Purpose |
+|-----------|---------|
+| `CREATE DICTIONARY` | Creates an external dictionary backed by a source connector |
+
+## Command Reference
+
+| Command | Description |
+|---------|-------------|
+| [CREATE DICTIONARY](create-dictionary.md) | Creates an external dictionary |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/17-dictionary/index.md
@@ -2,16 +2,10 @@
 title: Dictionary
 ---
 
-Dictionary-related SQL commands for external dictionaries in Databend.
+Dictionary provides a key-value approach for reading data from various external data sources, including MySQL and Redis.
 
-## Supported Statements
-
-| Statement | Purpose |
-|-----------|---------|
-| `CREATE DICTIONARY` | Creates an external dictionary backed by a source connector |
-
-## Command Reference
+## Dictionary Management
 
 | Command | Description |
 |---------|-------------|
-| [CREATE DICTIONARY](create-dictionary.md) | Creates an external dictionary |
+| [CREATE DICTIONARY](create-dictionary.md) | Creates a dictionary |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
@@ -41,9 +41,9 @@ These topics provide reference information for the DDL (Data Definition Language
 | **[Stream](04-stream/index.md)** | Capture and process data changes |
 | **[Task](04-task/index.md)** | Schedule and automate SQL operations |
 | **[Sequence](04-sequence/index.md)** | Generate unique sequential numbers |
-| **[Dictionary](17-dictionary/index.md)** | Define external dictionaries backed by external sources |
 | **[Connection](13-connection/index.md)** | Configure external data source connections |
 | **[File Format](13-file-format/index.md)** | Define formats for data import/export |
+| **[Dictionary](17-dictionary/index.md)** | Define dictionaries backed by external sources |
 
 ## Functions & Procedures
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
@@ -41,6 +41,7 @@ These topics provide reference information for the DDL (Data Definition Language
 | **[Stream](04-stream/index.md)** | Capture and process data changes |
 | **[Task](04-task/index.md)** | Schedule and automate SQL operations |
 | **[Sequence](04-sequence/index.md)** | Generate unique sequential numbers |
+| **[Dictionary](17-dictionary/index.md)** | Define external dictionaries backed by external sources |
 | **[Connection](13-connection/index.md)** | Configure external data source connections |
 | **[File Format](13-file-format/index.md)** | Define formats for data import/export |
 


### PR DESCRIPTION
## Summary
- add SQL reference pages for CREATE DICTIONARY in English and Chinese
- add a Dictionary section to the DDL overview
- add Dictionary category index pages

## Why
`CREATE DICTIONARY` is implemented in Databend, but the SQL reference site did not have a dedicated command page.

## Verification
- matched the syntax against the Databend parser and AST
- ran `git diff --check`
- did not run a docs build locally because `node_modules` is not installed in this environment