### PR TITLE
docs: add SHOW ONLINE NODES SQL reference

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
@@ -20,6 +20,7 @@ Databend Cloud 计算集群相关的 SQL 命令。
 | [CREATE WAREHOUSE](create-warehouse.md) | 创建计算集群 |
 | [USE WAREHOUSE](use-warehouse.md) | 切换当前会话的计算集群 |
 | [SHOW WAREHOUSES](show-warehouses.md) | 查看计算集群列表 |
+| [SHOW ONLINE NODES](show-online-nodes.md) | 查看系统管理的在线查询节点 |
 | [ALTER WAREHOUSE](alter-warehouse.md) | 暂停、恢复或修改计算集群配置 |
 | [DROP WAREHOUSE](drop-warehouse.md) | 删除计算集群 |
 | [REPLACE WAREHOUSE](replace-warehouse.md) | 重建计算集群 |

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/show-online-nodes.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/show-online-nodes.md
@@ -1,0 +1,35 @@
+---
+title: SHOW ONLINE NODES
+sidebar_position: 7
+---
+
+列出当前 tenant 可见的在线查询节点。
+
+:::note
+此命令依赖 system management 功能，并需要企业版许可证。
+:::
+
+## 语法
+
+```sql
+SHOW ONLINE NODES
+```
+
+## 输出
+
+`SHOW ONLINE NODES` 返回以下列：
+
+| 列名 | 说明 |
+|--------|-------------|
+| `id` | 节点标识 |
+| `type` | 节点类型，例如 `SelfManaged` 或 `SystemManaged` |
+| `group` | 节点组 |
+| `warehouse` | 计算集群标识 |
+| `cluster` | 集群标识 |
+| `version` | 二进制版本 |
+
+## 示例
+
+```sql
+SHOW ONLINE NODES;
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/show-online-nodes.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/show-online-nodes.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 列出当前 tenant 可见的在线查询节点。
 
 :::note
-此命令依赖 system management 功能，并需要企业版许可证。
+此命令依赖 system management 功能，并需要[企业版许可证](/guides/20-self-hosted/00-editions/enterprise/license)。
 :::
 
 ## 语法
@@ -23,7 +23,7 @@ SHOW ONLINE NODES
 |--------|-------------|
 | `id` | 节点标识 |
 | `type` | 节点类型，例如 `SelfManaged` 或 `SystemManaged` |
-| `group` | 节点组 |
+| `node_group` | 节点组 |
 | `warehouse` | 计算集群标识 |
 | `cluster` | 集群标识 |
 | `version` | 二进制版本 |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
@@ -55,6 +55,7 @@ Tags are returned in API responses and visible through `SHOW WAREHOUSES`.
 | [CREATE WAREHOUSE](create-warehouse.md) | Creates a new warehouse                           |
 | [USE WAREHOUSE](use-warehouse.md)       | Sets the current warehouse for the session        |
 | [SHOW WAREHOUSES](show-warehouses.md)   | Lists all warehouses with optional filtering      |
+| [SHOW ONLINE NODES](show-online-nodes.md) | Lists online query nodes managed by the system |
 | [ALTER WAREHOUSE](alter-warehouse.md)   | Suspends, resumes, or modifies warehouse settings |
 | [DROP WAREHOUSE](drop-warehouse.md)     | Removes a warehouse                               |
 | [QUERY_HISTORY](query-history.md)       | Inspects query logs for a warehouse               |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/show-online-nodes.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/show-online-nodes.md
@@ -1,0 +1,35 @@
+---
+title: SHOW ONLINE NODES
+sidebar_position: 7
+---
+
+Lists online query nodes visible to the current tenant.
+
+:::note
+This command requires system management support and an enterprise license.
+:::
+
+## Syntax
+
+```sql
+SHOW ONLINE NODES
+```
+
+## Output
+
+`SHOW ONLINE NODES` returns the following columns:
+
+| Column | Description |
+|--------|-------------|
+| `id` | Node identifier |
+| `type` | Node type, such as `SelfManaged` or `SystemManaged` |
+| `group` | Node group |
+| `warehouse` | Warehouse identifier |
+| `cluster` | Cluster identifier |
+| `version` | Binary version |
+
+## Example
+
+```sql
+SHOW ONLINE NODES;
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/show-online-nodes.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/show-online-nodes.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 Lists online query nodes visible to the current tenant.
 
 :::note
-This command requires system management support and an enterprise license.
+This command requires system management support and an [enterprise license](/guides/20-self-hosted/00-editions/enterprise/license).
 :::
 
 ## Syntax
@@ -23,7 +23,7 @@ SHOW ONLINE NODES
 |--------|-------------|
 | `id` | Node identifier |
 | `type` | Node type, such as `SelfManaged` or `SystemManaged` |
-| `group` | Node group |
+| `node_group` | Node group |
 | `warehouse` | Warehouse identifier |
 | `cluster` | Cluster identifier |
 | `version` | Binary version |


### PR DESCRIPTION
## Summary
- add SQL reference pages for SHOW ONLINE NODES in English and Chinese
- link the new command from the Warehouse index pages

## Why
`SHOW ONLINE NODES` is implemented in Databend, but the SQL reference site did not have a dedicated command page.

## Verification
- matched the syntax and output columns against the Databend parser and interpreter
- ran `git diff --check`
- did not run a docs build locally because `node_modules` is not installed in this environment