### PR TITLE
docs: add INSPECT WAREHOUSE SQL reference

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
@@ -20,6 +20,7 @@ Databend Cloud 计算集群相关的 SQL 命令。
 | [CREATE WAREHOUSE](create-warehouse.md) | 创建计算集群 |
 | [USE WAREHOUSE](use-warehouse.md) | 切换当前会话的计算集群 |
 | [SHOW WAREHOUSES](show-warehouses.md) | 查看计算集群列表 |
+| [INSPECT WAREHOUSE](inspect-warehouse.md) | 查看当前分配给计算集群的节点 |
 | [ALTER WAREHOUSE](alter-warehouse.md) | 暂停、恢复或修改计算集群配置 |
 | [DROP WAREHOUSE](drop-warehouse.md) | 删除计算集群 |
 | [REPLACE WAREHOUSE](replace-warehouse.md) | 重建计算集群 |

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/inspect-warehouse.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/inspect-warehouse.md
@@ -1,0 +1,32 @@
+---
+title: INSPECT WAREHOUSE
+sidebar_position: 7
+---
+
+显示当前分配给某个计算集群的节点。
+
+:::note
+此命令依赖 system management 功能，并需要企业版许可证。
+:::
+
+## 语法
+
+```sql
+INSPECT WAREHOUSE <warehouse_name>
+```
+
+## 输出
+
+`INSPECT WAREHOUSE` 返回以下列：
+
+| 列名 | 说明 |
+|--------|-------------|
+| `cluster` | 计算集群内部的 cluster 标识 |
+| `node` | 节点标识 |
+| `type` | 节点类型，例如 `SelfManaged` 或 `SystemManaged` |
+
+## 示例
+
+```sql
+INSPECT WAREHOUSE etl_wh;
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
@@ -55,6 +55,7 @@ Tags are returned in API responses and visible through `SHOW WAREHOUSES`.
 | [CREATE WAREHOUSE](create-warehouse.md) | Creates a new warehouse                           |
 | [USE WAREHOUSE](use-warehouse.md)       | Sets the current warehouse for the session        |
 | [SHOW WAREHOUSES](show-warehouses.md)   | Lists all warehouses with optional filtering      |
+| [INSPECT WAREHOUSE](inspect-warehouse.md) | Shows nodes currently assigned to a warehouse |
 | [ALTER WAREHOUSE](alter-warehouse.md)   | Suspends, resumes, or modifies warehouse settings |
 | [DROP WAREHOUSE](drop-warehouse.md)     | Removes a warehouse                               |
 | [QUERY_HISTORY](query-history.md)       | Inspects query logs for a warehouse               |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/inspect-warehouse.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/inspect-warehouse.md
@@ -1,0 +1,32 @@
+---
+title: INSPECT WAREHOUSE
+sidebar_position: 7
+---
+
+Shows the nodes currently assigned to a warehouse.
+
+:::note
+This command requires system management support and an enterprise license.
+:::
+
+## Syntax
+
+```sql
+INSPECT WAREHOUSE <warehouse_name>
+```
+
+## Output
+
+`INSPECT WAREHOUSE` returns the following columns:
+
+| Column | Description |
+|--------|-------------|
+| `cluster` | Cluster identifier inside the warehouse |
+| `node` | Node identifier |
+| `type` | Node type, such as `SelfManaged` or `SystemManaged` |
+
+## Example
+
+```sql
+INSPECT WAREHOUSE etl_wh;
+```


### PR DESCRIPTION
## Summary
- add SQL reference pages for INSPECT WAREHOUSE in English and Chinese
- link the new command from the Warehouse index pages

## Why
`INSPECT WAREHOUSE` is implemented in Databend, but the SQL reference site did not have a dedicated command page.

## Verification
- matched the syntax and output columns against the Databend parser and interpreter
- ran `git diff --check`
- did not run a docs build locally because `node_modules` is not installed in this environment