### PR TITLE
docs: add ALTER WAREHOUSE ASSIGN NODES SQL reference

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/assign-warehouse-nodes.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/assign-warehouse-nodes.md
@@ -1,0 +1,39 @@
+---
+title: ALTER WAREHOUSE ASSIGN NODES
+sidebar_position: 7
+---
+
+为某个计算集群中的一个或多个 cluster 分配节点。
+
+:::note
+此命令依赖 system management 功能，并需要企业版许可证。
+:::
+
+## 语法
+
+```sql
+ALTER WAREHOUSE <warehouse_name> ASSIGN NODES
+(
+    ASSIGN <node_count> NODES [ FROM '<node_group>' ] FOR <cluster_name>
+    [ , ASSIGN <node_count> NODES [ FROM '<node_group>' ] FOR <cluster_name> , ... ]
+)
+```
+
+## 参数
+
+| 参数 | 说明 |
+|-----------|-------------|
+| `<warehouse_name>` | 目标计算集群。 |
+| `<node_count>` | 要分配的节点数量。 |
+| `FROM '<node_group>'` | 可选的节点组选择器。 |
+| `<cluster_name>` | 计算集群内部的目标 cluster。 |
+
+## 示例
+
+```sql
+ALTER WAREHOUSE etl_wh ASSIGN NODES
+(
+    ASSIGN 2 NODES FOR c1,
+    ASSIGN 1 NODES FROM 'default' FOR c2
+);
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
@@ -20,6 +20,7 @@ Databend Cloud 计算集群相关的 SQL 命令。
 | [CREATE WAREHOUSE](create-warehouse.md) | 创建计算集群 |
 | [USE WAREHOUSE](use-warehouse.md) | 切换当前会话的计算集群 |
 | [SHOW WAREHOUSES](show-warehouses.md) | 查看计算集群列表 |
+| [ALTER WAREHOUSE ... ASSIGN NODES](assign-warehouse-nodes.md) | 为计算集群中的 cluster 分配节点 |
 | [ALTER WAREHOUSE](alter-warehouse.md) | 暂停、恢复或修改计算集群配置 |
 | [DROP WAREHOUSE](drop-warehouse.md) | 删除计算集群 |
 | [REPLACE WAREHOUSE](replace-warehouse.md) | 重建计算集群 |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/assign-warehouse-nodes.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/assign-warehouse-nodes.md
@@ -1,0 +1,39 @@
+---
+title: ALTER WAREHOUSE ASSIGN NODES
+sidebar_position: 7
+---
+
+Assigns nodes to one or more clusters in a warehouse.
+
+:::note
+This command requires system management support and an enterprise license.
+:::
+
+## Syntax
+
+```sql
+ALTER WAREHOUSE <warehouse_name> ASSIGN NODES
+(
+    ASSIGN <node_count> NODES [ FROM '<node_group>' ] FOR <cluster_name>
+    [ , ASSIGN <node_count> NODES [ FROM '<node_group>' ] FOR <cluster_name> , ... ]
+)
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `<warehouse_name>` | The target warehouse. |
+| `<node_count>` | Number of nodes to assign. |
+| `FROM '<node_group>'` | Optional node group selector. |
+| `<cluster_name>` | The target cluster inside the warehouse. |
+
+## Example
+
+```sql
+ALTER WAREHOUSE etl_wh ASSIGN NODES
+(
+    ASSIGN 2 NODES FOR c1,
+    ASSIGN 1 NODES FROM 'default' FOR c2
+);
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/19-warehouse/index.md
@@ -55,6 +55,7 @@ Tags are returned in API responses and visible through `SHOW WAREHOUSES`.
 | [CREATE WAREHOUSE](create-warehouse.md) | Creates a new warehouse                           |
 | [USE WAREHOUSE](use-warehouse.md)       | Sets the current warehouse for the session        |
 | [SHOW WAREHOUSES](show-warehouses.md)   | Lists all warehouses with optional filtering      |
+| [ALTER WAREHOUSE ... ASSIGN NODES](assign-warehouse-nodes.md) | Assigns nodes to warehouse clusters |
 | [ALTER WAREHOUSE](alter-warehouse.md)   | Suspends, resumes, or modifies warehouse settings |
 | [DROP WAREHOUSE](drop-warehouse.md)     | Removes a warehouse                               |
 | [QUERY_HISTORY](query-history.md)       | Inspects query logs for a warehouse               |


### PR DESCRIPTION
## Summary
- add SQL reference pages for ALTER WAREHOUSE ASSIGN NODES in English and Chinese
- link the new command from the Warehouse index pages

## Why
`ALTER WAREHOUSE ... ASSIGN NODES` is implemented in Databend, but the SQL reference site did not have a dedicated command page.

## Verification
- matched the syntax against the Databend parser, AST, binder, and interpreter
- ran `git diff --check`
- did not run a docs build locally because `node_modules` is not installed in this environment