### PR TITLE
docs: add DESCRIBE PIPE SQL reference

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/17-pipe/_category_.json
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/17-pipe/_category_.json
@@ -1,0 +1,1 @@
+{"label":"Pipe","position":17}

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/17-pipe/describe-pipe.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/17-pipe/describe-pipe.md
@@ -1,0 +1,20 @@
+---
+title: DESCRIBE PIPE
+sidebar_position: 1
+---
+
+显示 pipe 的属性信息。
+
+## 语法
+
+```sql
+DESCRIBE PIPE <name>
+```
+
+`DESC PIPE <name>` 也可以作为同义写法使用。
+
+## 示例
+
+```sql
+DESCRIBE PIPE my_pipe;
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/17-pipe/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/17-pipe/index.md
@@ -1,0 +1,6 @@
+---
+title: Pipe
+---
+| 命令 | 描述 |
+|---------|-------------|
+| [DESCRIBE PIPE](describe-pipe.md) | 显示 pipe 属性 |

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
@@ -38,6 +38,7 @@ title: DDL（Data Definition Language）命令
 | 组件 | 描述 |
 |-----------|-------------|
 | **[暂存区 (Stage)](03-stage/index.md)** | 为数据加载定义存储位置 |
+| **[Pipe](17-pipe/index.md)** | 查看导入管道信息 |
 | **[流 (Stream)](04-stream/index.md)** | 捕获和处理数据变更 |
 | **[任务 (Task)](04-task/index.md)** | 调度和自动化 SQL 操作 |
 | **[序列 (Sequence)](04-sequence/index.md)** | 生成唯一的序列号 |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/17-pipe/_category_.json
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/17-pipe/_category_.json
@@ -1,0 +1,1 @@
+{"label":"Pipe","position":17}

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/17-pipe/describe-pipe.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/17-pipe/describe-pipe.md
@@ -1,0 +1,20 @@
+---
+title: DESCRIBE PIPE
+sidebar_position: 1
+---
+
+Shows the properties of a pipe.
+
+## Syntax
+
+```sql
+DESCRIBE PIPE <name>
+```
+
+`DESC PIPE <name>` is accepted as a synonym.
+
+## Example
+
+```sql
+DESCRIBE PIPE my_pipe;
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/17-pipe/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/17-pipe/index.md
@@ -1,0 +1,6 @@
+---
+title: Pipe
+---
+| Command | Description |
+|---------|-------------|
+| [DESCRIBE PIPE](describe-pipe.md) | Shows pipe properties |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
@@ -38,6 +38,7 @@ These topics provide reference information for the DDL (Data Definition Language
 | Component | Description |
 |-----------|-------------|
 | **[Stage](03-stage/index.md)** | Define storage locations for data loading |
+| **[Pipe](17-pipe/index.md)** | Inspect ingestion pipes |
 | **[Stream](04-stream/index.md)** | Capture and process data changes |
 | **[Task](04-task/index.md)** | Schedule and automate SQL operations |
 | **[Sequence](04-sequence/index.md)** | Generate unique sequential numbers |


### PR DESCRIPTION
## Summary
- add SQL reference pages for DESCRIBE PIPE in English and Chinese
- add a Pipe section to the DDL overview
- add Pipe category index pages

## Why
`DESCRIBE PIPE` is implemented in Databend, but the SQL reference site did not have a dedicated command page.

## Verification
- matched the syntax against the Databend parser and AST
- ran `git diff --check`
- did not run a docs build locally because `node_modules` is not installed in this environment