### PR TITLE
docs: add SHOW CATALOGS SQL reference

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/09-catalog/_category_.json
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/09-catalog/_category_.json
@@ -1,0 +1,1 @@
+{"label":"Catalog","position":9}

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/09-catalog/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/09-catalog/index.md
@@ -1,0 +1,6 @@
+---
+title: Catalog
+---
+| 命令 | 描述 |
+|---------|-------------|
+| [SHOW CATALOGS](show-catalogs.md) | 列出 catalog |

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/09-catalog/show-catalogs.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/09-catalog/show-catalogs.md
@@ -1,0 +1,18 @@
+---
+title: SHOW CATALOGS
+sidebar_position: 1
+---
+
+列出 catalog。
+
+## 语法
+
+```sql
+SHOW CATALOGS [ LIKE '<pattern>' | WHERE <expr> ]
+```
+
+## 示例
+
+```sql
+SHOW CATALOGS;
+```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/index.md
@@ -8,6 +8,7 @@ title: DDL（Data Definition Language）命令
 
 | 组件 | 描述 |
 |-----------|-------------|
+| **[Catalog](09-catalog/index.md)** | 查看可用 catalog 列表 |
 | **[数据库](00-database/index.md)** | 创建、修改和删除数据库 |
 | **[表](01-table/index.md)** | 创建、修改和管理表 |
 | **[表版本管理 (Table Versioning)](21-table-versioning/index.md)** | 创建命名快照标签用于时间回溯 |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/09-catalog/_category_.json
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/09-catalog/_category_.json
@@ -1,0 +1,1 @@
+{"label":"Catalog","position":9}

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/09-catalog/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/09-catalog/index.md
@@ -1,0 +1,6 @@
+---
+title: Catalog
+---
+| Command | Description |
+|---------|-------------|
+| [SHOW CATALOGS](show-catalogs.md) | Lists catalogs |

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/09-catalog/show-catalogs.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/09-catalog/show-catalogs.md
@@ -1,0 +1,18 @@
+---
+title: SHOW CATALOGS
+sidebar_position: 1
+---
+
+Lists catalogs.
+
+## Syntax
+
+```sql
+SHOW CATALOGS [ LIKE '<pattern>' | WHERE <expr> ]
+```
+
+## Example
+
+```sql
+SHOW CATALOGS;
+```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/index.md
@@ -8,6 +8,7 @@ These topics provide reference information for the DDL (Data Definition Language
 
 | Component | Description |
 |-----------|-------------|
+| **[Catalog](09-catalog/index.md)** | List available catalogs |
 | **[Database](00-database/index.md)** | Create, alter, and drop databases |
 | **[Table](01-table/index.md)** | Create, alter, and manage tables |
 | **[Table Versioning](21-table-versioning/index.md)** | Create named snapshot tags for time travel |


### PR DESCRIPTION
## Summary
- add SQL reference pages for SHOW CATALOGS in English and Chinese
- add a Catalog section to the DDL overview
- add Catalog category index pages

## Why
`SHOW CATALOGS` is implemented in Databend, but the SQL reference site did not have a dedicated command page.

## Verification
- matched the syntax against the Databend parser and binder
- ran `git diff --check`
- did not run a docs build locally because `node_modules` is not installed in this environment