### PR TITLE
docs: add VACUUM VIRTUAL COLUMN SQL reference

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/50-administration-cmds/10-vacuum-virtual-column.md
+++ b/docs/cn/sql-reference/10-sql-commands/50-administration-cmds/10-vacuum-virtual-column.md
@@ -1,0 +1,19 @@
+---
+title: VACUUM VIRTUAL COLUMN
+---
+
+删除某张表过期的虚拟列文件。
+
+:::note
+此命令需要虚拟列企业版功能。
+:::
+
+## 语法
+
+```sql
+VACUUM VIRTUAL COLUMN FROM [ <catalog_name>. ][ <database_name>. ]<table_name>
+```
+
+## 输出
+
+返回被删除文件的数量。

--- a/docs/cn/sql-reference/10-sql-commands/50-administration-cmds/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/50-administration-cmds/index.md
@@ -43,6 +43,7 @@ title: 管理命令
 | **[VACUUM TABLE](09-vacuum-table.md)** | 回收表的存储空间 |
 | **[VACUUM DROP TABLE](09-vacuum-drop-table.md)** | 清理已删除表的数据 |
 | **[VACUUM TEMP FILES](09-vacuum-temp-files.md)** | 移除临时文件 |
+| **[VACUUM VIRTUAL COLUMN](10-vacuum-virtual-column.md)** | 删除过期的虚拟列文件 |
 | **[SHOW INDEXES](show-indexes.md)** | 显示表索引（Index） |
 
 ## 动态执行

--- a/docs/en/sql-reference/10-sql-commands/50-administration-cmds/10-vacuum-virtual-column.md
+++ b/docs/en/sql-reference/10-sql-commands/50-administration-cmds/10-vacuum-virtual-column.md
@@ -1,0 +1,19 @@
+---
+title: VACUUM VIRTUAL COLUMN
+---
+
+Removes obsolete virtual column files for a table.
+
+:::note
+This command requires the virtual column enterprise feature.
+:::
+
+## Syntax
+
+```sql
+VACUUM VIRTUAL COLUMN FROM [ <catalog_name>. ][ <database_name>. ]<table_name>
+```
+
+## Output
+
+Returns the number of removed files.

--- a/docs/en/sql-reference/10-sql-commands/50-administration-cmds/index.md
+++ b/docs/en/sql-reference/10-sql-commands/50-administration-cmds/index.md
@@ -43,6 +43,7 @@ This page provides reference information for the system administration commands 
 | **[VACUUM TABLE](09-vacuum-table.md)** | Reclaim storage space from tables |
 | **[VACUUM DROP TABLE](09-vacuum-drop-table.md)** | Clean up dropped table data |
 | **[VACUUM TEMP FILES](09-vacuum-temp-files.md)** | Remove temporary files |
+| **[VACUUM VIRTUAL COLUMN](10-vacuum-virtual-column.md)** | Remove obsolete virtual column files |
 | **[SHOW INDEXES](show-indexes.md)** | Display table indexes |
 
 ## Dynamic Execution


### PR DESCRIPTION
## Summary
- add SQL reference pages for VACUUM VIRTUAL COLUMN in English and Chinese
- link the new command from the Administration Commands index pages

## Why
`VACUUM VIRTUAL COLUMN` is implemented in Databend, but the SQL reference site did not have a dedicated command page.

## Verification
- matched the syntax and output behavior against the Databend parser, AST, and interpreter
- ran `git diff --check`
- did not run a docs build locally because `node_modules` is not installed in this environment