### PR TITLE
docs: sync docker-compose healthcheck and entrypoint with reference config

### DIFF
--- a/docs/cn/guides/20-self-hosted/02-deployment/01-deploying-local.md
+++ b/docs/cn/guides/20-self-hosted/02-deployment/01-deploying-local.md
@@ -54,11 +54,11 @@ services:
     volumes:
       - databend-meta-data:/data/
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:28101/v1/health"]
+      test: ["CMD", "databend-metactl", "--grpc-api-address", "0.0.0.0:9191", "status"]
       interval: 5s
       timeout: 3s
       retries: 10
-    entrypoint: sh -c "/databend-meta \
+    entrypoint: sh -c "databend-meta \
         --log-file-level='warn' \
         --log-file-format='text' \
         --log-file-dir='/data/logs/' \

--- a/docs/cn/guides/20-self-hosted/02-deployment/01-deploying-local.md
+++ b/docs/cn/guides/20-self-hosted/02-deployment/01-deploying-local.md
@@ -127,7 +127,7 @@ services:
       secret_access_key = 'minioadmin'
       bucket = 'databend'
       EOF
-      exec /usr/bin/databend-query --config-file=/etc/databend/databend-query.toml
+      exec databend-query --config-file=/etc/databend/databend-query.toml
       "
 
 volumes:

--- a/docs/en/guides/20-self-hosted/02-deployment/01-deploying-local.md
+++ b/docs/en/guides/20-self-hosted/02-deployment/01-deploying-local.md
@@ -121,7 +121,7 @@ services:
       secret_access_key = 'minioadmin'
       bucket = 'databend'
       EOF
-      exec /usr/bin/databend-query --config-file=/etc/databend/databend-query.toml
+      exec databend-query --config-file=/etc/databend/databend-query.toml
       "
 
 volumes:

--- a/docs/en/guides/20-self-hosted/02-deployment/01-deploying-local.md
+++ b/docs/en/guides/20-self-hosted/02-deployment/01-deploying-local.md
@@ -48,11 +48,11 @@ services:
     volumes:
       - databend-meta-data:/data/
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:28101/v1/health"]
+      test: ["CMD", "databend-metactl", "--grpc-api-address", "0.0.0.0:9191", "status"]
       interval: 5s
       timeout: 3s
       retries: 10
-    entrypoint: sh -c "/databend-meta \
+    entrypoint: sh -c "databend-meta \
         --log-file-level='warn' \
         --log-file-format='text' \
         --log-file-dir='/data/logs/' \


### PR DESCRIPTION
## Summary
- Replace `curl` healthcheck with `databend-metactl` for `databend-meta` (more reliable, no curl dependency)
- Remove hardcoded `/` path prefix from `databend-meta` entrypoint, use PATH lookup instead
- Applied to both EN and CN docs

## Test plan
- [x] Verify `docker compose up -d` works with updated config
- [x] Confirm healthcheck passes via `databend-metactl`

🤖 Generated with [Claude Code](https://claude.com/code)