### PR TITLE
docs: fix password hash and improve docker-compose config

### DIFF
--- a/docs/cn/guides/20-self-hosted/02-deployment/01-deploying-local.md
+++ b/docs/cn/guides/20-self-hosted/02-deployment/01-deploying-local.md
@@ -54,11 +54,11 @@ services:
     volumes:
       - databend-meta-data:/data/
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:28101/v1/health"]
+      test: ["CMD", "databend-metactl", "--grpc-api-address", "0.0.0.0:9191", "status"]
       interval: 5s
       timeout: 3s
       retries: 10
-    entrypoint: sh -c "/databend-meta \
+    entrypoint: sh -c "databend-meta \
         --log-file-level='warn' \
         --log-file-format='text' \
         --log-file-dir='/data/logs/' \
@@ -103,7 +103,8 @@ services:
       name = 'databend'
       auth_type = 'double_sha1_password'
       # password: databend
-      auth_string = '3081f32caef285c232d066033c89a96d542d09d7'
+      # 生成方式: echo -n "your_password" | sha1sum | cut -d' ' -f1 | xxd -r -p | sha1sum
+      auth_string = '3081f32caef285c232d066033c89a78d88a6d8a5'
 
       [log]
       [log.file]
@@ -127,7 +128,7 @@ services:
       secret_access_key = 'minioadmin'
       bucket = 'databend'
       EOF
-      exec /usr/bin/databend-query --config-file=/etc/databend/databend-query.toml
+      exec databend-query --config-file=/etc/databend/databend-query.toml
       "
 
 volumes:

--- a/docs/en/guides/20-self-hosted/02-deployment/01-deploying-local.md
+++ b/docs/en/guides/20-self-hosted/02-deployment/01-deploying-local.md
@@ -48,11 +48,11 @@ services:
     volumes:
       - databend-meta-data:/data/
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:28101/v1/health"]
+      test: ["CMD", "databend-metactl", "--grpc-api-address", "0.0.0.0:9191", "status"]
       interval: 5s
       timeout: 3s
       retries: 10
-    entrypoint: sh -c "/databend-meta \
+    entrypoint: sh -c "databend-meta \
         --log-file-level='warn' \
         --log-file-format='text' \
         --log-file-dir='/data/logs/' \
@@ -97,7 +97,8 @@ services:
       name = 'databend'
       auth_type = 'double_sha1_password'
       # password: databend
-      auth_string = '3081f32caef285c232d066033c89a96d542d09d7'
+      # generate: echo -n "your_password" | sha1sum | cut -d' ' -f1 | xxd -r -p | sha1sum
+      auth_string = '3081f32caef285c232d066033c89a78d88a6d8a5'
 
       [log]
       [log.file]
@@ -121,7 +122,7 @@ services:
       secret_access_key = 'minioadmin'
       bucket = 'databend'
       EOF
-      exec /usr/bin/databend-query --config-file=/etc/databend/databend-query.toml
+      exec databend-query --config-file=/etc/databend/databend-query.toml
       "
 
 volumes:


### PR DESCRIPTION
## Summary
- Use `databend-metactl` for meta healthcheck instead of curl
- Remove hardcoded path prefixes (`/databend-meta`, `/usr/bin/databend-query`) from entrypoints
- Fix double SHA1 hash for databend user password (`3081f32caef285c232d066033c89a78d88a6d8a5`)
- Add comment showing how to generate `double_sha1_password` hash
- Applied to both EN and CN docs

## Test plan
- [ ] Verify `docker compose up -d` works with updated config
- [ ] Confirm `bendsql -u databend -p databend` connects successfully

🤖 Generated with [Claude Code](https://claude.com/code)