### PR TITLE
docs: fix double SHA1 password hash and add generation command

### DIFF
--- a/docs/cn/guides/20-self-hosted/02-deployment/01-deploying-local.md
+++ b/docs/cn/guides/20-self-hosted/02-deployment/01-deploying-local.md
@@ -103,7 +103,8 @@ services:
       name = 'databend'
       auth_type = 'double_sha1_password'
       # password: databend
-      auth_string = '3081f32caef285c232d066033c89a96d542d09d7'
+      # 生成方式: echo -n "your_password" | sha1sum | cut -d' ' -f1 | xxd -r -p | sha1sum
+      auth_string = '3081f32caef285c232d066033c89a78d88a6d8a5'
 
       [log]
       [log.file]

--- a/docs/en/guides/20-self-hosted/02-deployment/01-deploying-local.md
+++ b/docs/en/guides/20-self-hosted/02-deployment/01-deploying-local.md
@@ -97,7 +97,8 @@ services:
       name = 'databend'
       auth_type = 'double_sha1_password'
       # password: databend
-      auth_string = '3081f32caef285c232d066033c89a96d542d09d7'
+      # generate: echo -n "your_password" | sha1sum | cut -d' ' -f1 | xxd -r -p | sha1sum
+      auth_string = '3081f32caef285c232d066033c89a78d88a6d8a5'
 
       [log]
       [log.file]


### PR DESCRIPTION
## Summary
- Fix incorrect `auth_string` hash for databend user (was `3081f32caef285c232d066033c89a96d542d09d7`, correct is `3081f32caef285c232d066033c89a78d88a6d8a5`)
- Add comment showing how to generate the hash: `echo -n "your_password" | sha1sum | cut -d' ' -f1 | xxd -r -p | sha1sum`
- Applied to both EN and CN docs

🤖 Generated with [Claude Code](https://claude.com/code)