### PR TITLE
docs: update key-pair auth RFC with SHOW PUBLIC KEYS and DESC USER changes

### DIFF
--- a/docs/cn/developer/20-community/02-rfcs/20260428-key-pair-auth.md
+++ b/docs/cn/developer/20-community/02-rfcs/20260428-key-pair-auth.md
@@ -229,7 +229,7 @@ openssl pkey -pubin -in key.pem -outform DER | openssl dgst -sha256 -binary | ba
 
 用于：
 
-- `DESC USER` 输出中标识密钥，无需暴露完整 PEM。
+- `SHOW PUBLIC KEYS FOR USER` 输出中标识密钥，无需暴露完整 PEM。
 - `REMOVE PUBLIC_KEY` 指定要移除的密钥。
 
 ### 支持的算法

--- a/docs/cn/developer/20-community/02-rfcs/20260428-key-pair-auth.md
+++ b/docs/cn/developer/20-community/02-rfcs/20260428-key-pair-auth.md
@@ -3,7 +3,7 @@ title: 密钥对认证
 description: 基于公钥密码学的用户密钥对认证 RFC。
 ---
 
-- Tracking Issue: TBD
+- Tracking Issue: https://github.com/databendlabs/databend/pull/19786
 
 ## 概述
 
@@ -66,8 +66,11 @@ ALTER USER service_account WITH ADD PUBLIC_KEY = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ
 ALTER USER service_account WITH REMOVE PUBLIC_KEY LABEL = 'ci-pipeline';
 ALTER USER service_account WITH REMOVE PUBLIC_KEY FINGERPRINT = 'SHA256:abc123...';
 
--- 查看密钥指纹、标签和创建时间
+-- 查看密钥数量
 DESC USER service_account;
+
+-- 查看密钥指纹、标签和创建时间
+SHOW PUBLIC KEYS FOR USER service_account;
 ```
 
 输入时接受完整 PEM 格式（带 `-----BEGIN PUBLIC KEY-----` header）或纯 base64 编码的密钥体。内部只存储 base64 体。为方便在 SQL 字符串中使用，建议使用单行 base64 体 — 可避免 SQL 字面量中的换行/转义问题。
@@ -171,7 +174,15 @@ ALTER USER <username> WITH REMOVE PUBLIC_KEY FINGERPRINT = '<sha256_fingerprint>
 
 如果用户已经使用密钥对认证，在 ALTER USER 中使用 `IDENTIFIED WITH key_pair BY '<key>'` 会被拒绝 — 请使用 `ADD PUBLIC_KEY` / `REMOVE PUBLIC_KEY` 来管理密钥。这可以防止意外替换所有现有密钥。
 
-**DESCRIBE USER**：显示所有存储公钥的 SHA256 指纹、标签和创建时间。
+**DESCRIBE USER**：在 `public_keys` 列中以整数形式显示存储的公钥数量。
+
+**SHOW PUBLIC KEYS FOR USER**：
+
+```sql
+SHOW PUBLIC KEYS FOR USER <username>;
+```
+
+每个密钥返回一行，包含 `fingerprint`、`label`、`created_at` 列。这是查看密钥详情的主要方式。
 
 ### 约束
 

--- a/docs/en/developer/20-community/02-rfcs/20260428-key-pair-auth.md
+++ b/docs/en/developer/20-community/02-rfcs/20260428-key-pair-auth.md
@@ -3,7 +3,7 @@ title: Key-Pair Authentication
 description: RFC for per-user key-pair authentication using public key cryptography.
 ---
 
-- Tracking Issue: TBD
+- Tracking Issue: https://github.com/databendlabs/databend/pull/19786
 
 ## Summary
 
@@ -66,8 +66,11 @@ ALTER USER service_account WITH ADD PUBLIC_KEY = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ
 ALTER USER service_account WITH REMOVE PUBLIC_KEY LABEL = 'ci-pipeline';
 ALTER USER service_account WITH REMOVE PUBLIC_KEY FINGERPRINT = 'SHA256:abc123...';
 
--- View key fingerprints, labels, and creation times
+-- View key count
 DESC USER service_account;
+
+-- View key fingerprints, labels, and creation times
+SHOW PUBLIC KEYS FOR USER service_account;
 ```
 
 Both full PEM format (with `-----BEGIN PUBLIC KEY-----` headers) and bare base64-encoded key body are accepted as input. Internally, only the base64 body is stored. For convenience in SQL strings, the one-line base64 body is recommended — it avoids newline/escaping issues in SQL literals.
@@ -171,7 +174,15 @@ ALTER USER <username> WITH REMOVE PUBLIC_KEY FINGERPRINT = '<sha256_fingerprint>
 
 Using `IDENTIFIED WITH key_pair BY '<key>'` in ALTER USER is rejected if the user already uses key-pair authentication — use `ADD PUBLIC_KEY` / `REMOVE PUBLIC_KEY` to manage keys instead. This prevents accidental replacement of all existing keys.
 
-**DESCRIBE USER**: Shows SHA256 fingerprints, labels, and creation timestamps of all stored public keys.
+**DESCRIBE USER**: Shows the number of stored public keys as an integer in the `public_keys` column.
+
+**SHOW PUBLIC KEYS FOR USER**:
+
+```sql
+SHOW PUBLIC KEYS FOR USER <username>;
+```
+
+Returns one row per key with columns: `fingerprint`, `label`, `created_at`. This is the primary way to inspect key details.
 
 ### Constraints
 

--- a/docs/en/developer/20-community/02-rfcs/20260428-key-pair-auth.md
+++ b/docs/en/developer/20-community/02-rfcs/20260428-key-pair-auth.md
@@ -229,7 +229,7 @@ openssl pkey -pubin -in key.pem -outform DER | openssl dgst -sha256 -binary | ba
 
 This is used for:
 
-- `DESC USER` output to identify keys without exposing the full key.
+- `SHOW PUBLIC KEYS FOR USER` output to identify keys without exposing the full key.
 - `REMOVE PUBLIC_KEY FINGERPRINT` to specify which key to remove.
 
 ### Supported Algorithms


### PR DESCRIPTION
## Summary

Update the key-pair authentication RFC to reflect implementation changes in databendlabs/databend#19786.

### Changes

- Add tracking issue link
- `DESC USER` now shows key count (UInt64) instead of fingerprint strings
- Add `SHOW PUBLIC KEYS FOR USER <user>` syntax — returns one row per key with fingerprint, label, created_at
- Updated both EN and CN versions