### PR TITLE
docs: remove iss claim requirement from key-pair auth RFC

### DIFF
--- a/docs/cn/developer/20-community/02-rfcs/20260428-key-pair-auth.md
+++ b/docs/cn/developer/20-community/02-rfcs/20260428-key-pair-auth.md
@@ -85,11 +85,10 @@ X-DATABEND-AUTH-METHOD: keypair
 
 JWT 必须包含：
 - `sub`（主题）：用户名
-- `iss`（签发者）：`<tenant>.<username>` — 将 token 绑定到特定租户和用户，防止跨租户重放
 - `iat`（签发时间）：当前时间戳
 - `exp`（过期时间）：短 TTL（建议 60 秒）
 
-服务端在验证签名之前，先验证 `iss` 声明是否与当前租户和 `sub` 声明匹配。如果任何存储的公钥验证签名成功，则认证通过。
+服务端通过 `sub` 查找用户，然后用存储的公钥验证 JWT 签名。如果任何存储的公钥验证签名成功，则认证通过。
 
 ### 密码短语支持
 
@@ -190,13 +189,12 @@ ALTER USER <username> WITH REMOVE PUBLIC_KEY FINGERPRINT = '<sha256_fingerprint>
    - 如果为 `keypair`：路由到密钥对认证流程。
    - 否则：路由到现有的 JWKS JWT 验证流程（不变）。
 3. 密钥对流程：
-   a. 不验证签名，解码 JWT payload 提取 `sub`（用户名）和 `iss`（签发者）声明。
-   b. 验证 `iss` 匹配 `<tenant>.<username>`。缺失或不匹配则拒绝。
-   c. 通过用户名在 meta 中查找用户。
-   d. 验证用户的 `auth_info` 为 `AuthInfo::KeyPair`。
-   e. 遍历存储的公钥，尝试用每个公钥验证 JWT 签名。首次匹配即接受。
-   f. 验证标准 JWT 声明：`exp` 不能过期，`iat` 必须存在且不能在未来。
-   g. 执行网络策略，设置已认证用户会话。
+   a. 不验证签名，解码 JWT payload 提取 `sub`（用户名）声明。
+   b. 通过用户名在 meta 中查找用户。
+   c. 验证用户的 `auth_info` 为 `AuthInfo::KeyPair`。
+   d. 遍历存储的公钥，尝试用每个公钥验证 JWT 签名。首次匹配即接受。
+   e. 验证标准 JWT 声明：`exp` 不能过期，`iat` 必须存在且不能在未来。
+   f. 执行网络策略，设置已认证用户会话。
 
 ### 密钥验证
 
@@ -254,14 +252,12 @@ openssl pkey -pubin -in key.pem -outform DER | openssl dgst -sha256 -binary | ba
 ```json
 {
   "sub": "service_account",
-  "iss": "my_tenant.service_account",
   "iat": 1714300000,
   "exp": 1714300060
 }
 ```
 
 - `sub`（必需）：Databend 用户名。
-- `iss`（必需）：签发者，格式为 `<tenant>.<username>`。服务端验证此声明以防止跨租户重放。
 - `iat`（必需）：签发时间戳。
 - `exp`（必需）：过期时间戳。建议 TTL 为 60 秒。
 

--- a/docs/en/developer/20-community/02-rfcs/20260428-key-pair-auth.md
+++ b/docs/en/developer/20-community/02-rfcs/20260428-key-pair-auth.md
@@ -85,11 +85,10 @@ The `X-DATABEND-AUTH-METHOD: keypair` header is required. Without it, the server
 
 The JWT must contain:
 - `sub` (subject): the username
-- `iss` (issuer): `<tenant>.<username>` — binds the token to a specific tenant and user, preventing cross-tenant replay
 - `iat` (issued at): current timestamp
 - `exp` (expiration): a short TTL (e.g., 60 seconds)
 
-The server validates the `iss` claim against the current tenant and `sub` claim before verifying the signature. If any stored key validates the signature, authentication succeeds.
+The server looks up the user by `sub`, then verifies the JWT signature against the user's stored public keys. If any stored key validates the signature, authentication succeeds.
 
 ### Passphrase Support
 
@@ -190,10 +189,9 @@ When a Bearer JWT token arrives at the HTTP handler:
    - If `keypair`: route to key-pair authentication flow.
    - Otherwise: route to existing JWKS-based JWT verification (unchanged).
 3. Key-pair flow:
-   a. Decode the JWT payload without verification to extract the `sub` (username) and `iss` (issuer) claims.
-   b. Validate `iss` matches `<tenant>.<username>`. Reject if missing or mismatched.
-   c. Look up the user in meta by username.
-   d. Verify the user's `auth_info` is `AuthInfo::KeyPair`.
+   a. Decode the JWT payload without verification to extract the `sub` (username) claim.
+   b. Look up the user in meta by username.
+   c. Verify the user's `auth_info` is `AuthInfo::KeyPair`.
    d. Iterate over stored public keys, attempt to verify the JWT signature with each. Accept on first match.
    e. Validate standard JWT claims: `exp` must not be in the past, `iat` must be present and not in the future.
    f. Enforce network policy, set authenticated user in session.
@@ -254,14 +252,12 @@ The client-generated JWT must follow this structure:
 ```json
 {
   "sub": "service_account",
-  "iss": "my_tenant.service_account",
   "iat": 1714300000,
   "exp": 1714300060
 }
 ```
 
 - `sub` (required): The Databend username.
-- `iss` (required): Issuer in `<tenant>.<username>` format. Validated by the server to prevent cross-tenant replay.
 - `iat` (required): Issued-at timestamp.
 - `exp` (required): Expiration timestamp. Recommended TTL is 60 seconds.
 


### PR DESCRIPTION
## Summary

Remove the `iss` (issuer) claim requirement from key-pair JWT authentication.

### Why

The `iss` claim required `<tenant>.<username>` format, but Databend's tenant is a server-side concept not exposed to clients — `bendsql` doesn't send a tenant header. This created a chicken-and-egg problem: clients couldn't construct the JWT without knowing the tenant, but needed to authenticate first to discover it.

### Changes

JWT now only requires:
- `sub` (required): username
- `iat` (required): issued-at timestamp
- `exp` (required): expiration timestamp

Updated both EN and CN versions.

### Context

Follow-up to databendlabs/databend#19786 and databendlabs/databend-docs#3382.