### PR TITLE
docs: improve MCP client integration guide

### DIFF
--- a/docs/cn/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/cn/guides/51-ai-functions/03-mcp-integration.md
@@ -9,32 +9,39 @@ import TabItem from '@theme/TabItem';
 
 ## 概览
 
-[Databend MCP](https://github.com/databendlabs/mcp-databend) 基于 Model Context Protocol 协议，将 Databend 的数据能力无缝集成到您的 AI 助手工作流中。支持 Claude Code、Codex、Cursor、Claude Desktop、VS Code 等主流 MCP 客户端。
+[Databend MCP](https://github.com/databendlabs/mcp-databend) 基于 Model Context Protocol 协议，将 Databend 连接到 AI 助手工作流。支持 Codex、Kimi Code、Cursor、Claude Code、Claude Desktop、Gemini CLI、VS Code 以及其他兼容 MCP 的客户端。
 
 **核心能力：**
 
-- **智能 SQL 生成**：根据业务需求自动生成复杂的 SQL 查询。
-- **自动化运维**：直接创建和管理定时数据管道任务。
-- **交互式探索**：即时查看数据库 Schema 结构并校验查询语法。
-- **ETL 工作流**：流畅执行 COPY、MERGE 和 Stage 文件操作。
+- 根据自然语言需求生成复杂 SQL 查询。
+- 探索数据库、表、Schema、Stage 和 Connection。
+- 在执行前校验查询语法。
+- 使用 COPY、MERGE 和 Stage 操作构建 ETL 工作流。
+- 创建和管理定时数据管道任务。
 
-例如：_"创建一个定时任务，每分钟从 @my_stage 复制 parquet 文件到 orders 表，并验证任务是否正常运行。"_
+例如：_“创建一个定时任务，每分钟从 @my_stage 复制 parquet 文件到 orders 表，并验证任务是否正常运行。”_
 
 ## 安装
 
-### 1. 获取连接信息
+### 1. 获取 Databend 连接信息
 
 推荐使用 **Databend Cloud** 以获得开箱即用的体验。
 
-1.  登录 [Databend Cloud](https://app.databend.cn)。
-2.  点击 **与 AI 工具连接**。
-3.  获取常规连接信息（Host, User, Password 等）。
-4.  复制完整 DSN，格式如下：
-    `databend://user:pwd@host:443/database?warehouse=warehouse_name`
+1. 登录 [Databend Cloud](https://app.databend.cn)。
+2. 点击 **与 AI 工具连接**。
+3. 选择 MCP Server 使用的数据库和计算集群。
+4. 除非明确需要让 Agent 写入生产对象，否则建议保持 **会话沙箱防护** 开启。
+5. 复制完整 DSN，格式如下：
+
+   ```text
+   databend://user:password@host:443/database?warehouse=warehouse_name
+   ```
 
 ![与 AI 工具连接](@site/static/img/connect/ai-tools.png)
 
 ### 2. 配置 MCP 客户端
+
+默认使用 `DATABEND_MCP_SAFE_MODE=true`。在安全模式下，AI Agent 对生产数据保持只读，写操作仅限于会话沙箱对象。
 
 <Tabs groupId="mcp-clients">
 
@@ -42,21 +49,21 @@ import TabItem from '@theme/TabItem';
 
 ```bash
 codex mcp add databend \
-  --env DATABEND_DSN='databend://user:password@host:port/database?warehouse=your_warehouse' \
-  --env SAFE_MODE='false' \
-  -- uv tool run mcp-databend
+  --env DATABEND_DSN='databend://user:password@host:443/database?warehouse=your_warehouse' \
+  --env DATABEND_MCP_SAFE_MODE=true \
+  -- uv tool run --from mcp-databend@latest mcp-databend
 ```
 
-或添加到 `~/.codex/config.toml`:
+或添加到 `~/.codex/config.toml`：
 
 ```toml
 [mcp_servers.databend]
 command = "uv"
-args = ["tool", "run", "mcp-databend"]
+args = ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"]
 
 [mcp_servers.databend.env]
-DATABEND_DSN = "databend://user:password@host:port/database?warehouse=your_warehouse"
-SAFE_MODE = "false"
+DATABEND_DSN = "databend://user:password@host:443/database?warehouse=your_warehouse"
+DATABEND_MCP_SAFE_MODE = "true"
 ```
 
 </TabItem>
@@ -65,26 +72,33 @@ SAFE_MODE = "false"
 
 ```bash
 claude mcp add databend \
-  --env DATABEND_DSN='databend://user:password@host:port/database?warehouse=your_warehouse' \
-  --env SAFE_MODE='false' \
-  -- uv tool run mcp-databend
+  --env DATABEND_DSN='databend://user:password@host:443/database?warehouse=your_warehouse' \
+  --env DATABEND_MCP_SAFE_MODE=true \
+  -- uv tool run --from mcp-databend@latest mcp-databend
 ```
 
 </TabItem>
 
-<TabItem value="gemini-cli" label="Gemini CLI">
+<TabItem value="kimi-code" label="Kimi Code">
 
-添加到 `~/.gemini/settings.json`:
+```bash
+kimi mcp add --transport stdio databend \
+  --env DATABEND_DSN='databend://user:password@host:443/database?warehouse=your_warehouse' \
+  --env DATABEND_MCP_SAFE_MODE=true \
+  -- uv tool run --from mcp-databend@latest mcp-databend
+```
+
+或添加到 `~/.kimi/mcp.json`：
 
 ```json
 {
   "mcpServers": {
     "databend": {
       "command": "uv",
-      "args": ["tool", "run", "mcp-databend"],
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
       "env": {
-        "DATABEND_DSN": "databend://user:password@host:port/database?warehouse=your_warehouse",
-        "SAFE_MODE": "false"
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
       }
     }
   }
@@ -95,17 +109,38 @@ claude mcp add databend \
 
 <TabItem value="cursor" label="Cursor">
 
-添加到 `~/.cursor/mcp.json`:
+添加到 `~/.cursor/mcp.json`：
 
 ```json
 {
   "mcpServers": {
     "databend": {
       "command": "uv",
-      "args": ["tool", "run", "mcp-databend"],
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
       "env": {
-        "DATABEND_DSN": "databend://user:password@host:port/database?warehouse=your_warehouse",
-        "SAFE_MODE": "false"
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="gemini-cli" label="Gemini CLI">
+
+添加到 `~/.gemini/settings.json`：
+
+```json
+{
+  "mcpServers": {
+    "databend": {
+      "command": "uv",
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
+      "env": {
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
       }
     }
   }
@@ -116,17 +151,17 @@ claude mcp add databend \
 
 <TabItem value="claude-desktop" label="Claude Desktop">
 
-添加到 `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) 或 `%APPDATA%/Claude/claude_desktop_config.json` (Windows):
+添加到 macOS 的 `~/Library/Application Support/Claude/claude_desktop_config.json`，或 Windows 的 `%APPDATA%\Claude\claude_desktop_config.json`：
 
 ```json
 {
   "mcpServers": {
     "databend": {
       "command": "uv",
-      "args": ["tool", "run", "mcp-databend"],
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
       "env": {
-        "DATABEND_DSN": "databend://user:password@host:port/database?warehouse=your_warehouse",
-        "SAFE_MODE": "false"
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
       }
     }
   }
@@ -137,17 +172,17 @@ claude mcp add databend \
 
 <TabItem value="vscode" label="VS Code">
 
-添加到 `.vscode/mcp.json`:
+打开 **Preferences: Open User Settings (JSON)**，添加：
 
 ```json
 {
-  "mcpServers": {
+  "mcp.servers": {
     "databend": {
       "command": "uv",
-      "args": ["tool", "run", "mcp-databend"],
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
       "env": {
-        "DATABEND_DSN": "databend://user:password@host:port/database?warehouse=your_warehouse",
-        "SAFE_MODE": "false"
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
       }
     }
   }
@@ -159,15 +194,26 @@ claude mcp add databend \
 <TabItem value="manual" label="Manual">
 
 ```bash
-export DATABEND_DSN="databend://user:password@host:port/database?warehouse=your_warehouse"
-export SAFE_MODE="false"
+export DATABEND_DSN="databend://user:password@host:443/database?warehouse=your_warehouse"
+export DATABEND_MCP_SAFE_MODE=true
 
-uv tool run mcp-databend
+uv tool run --from mcp-databend@latest mcp-databend
 ```
 
 </TabItem>
 
 </Tabs>
+
+## 会话沙箱防护
+
+`DATABEND_MCP_SAFE_MODE` 用于控制 MCP Server 是否启用会话沙箱防护。
+
+| 值 | 行为 | 推荐场景 |
+| -- | ---- | -------- |
+| `true` | Agent 对生产对象只读。写操作仅允许落在 `mcp_sandbox_{session_id}_*` 等会话沙箱对象上。 | 默认推荐，适合大多数 AI 工具场景。 |
+| `false` | MCP Server 可写入该 Databend 用户权限允许的对象。 | 仅在可信 Agent 和最小权限 Databend 用户场景下使用。 |
+
+大多数场景建议保持安全模式开启。只有当 Agent 必须修改真实生产对象，并且 Databend 用户已配置最小必要权限时，才建议关闭。
 
 ## 功能列表
 
@@ -175,9 +221,9 @@ uv tool run mcp-databend
 
 | 工具             | 说明                      |
 | ---------------- | ------------------------- |
-| `execute_sql`    | 执行 SQL (含超时保护)     |
+| `execute_sql`    | 执行 SQL（含超时保护）    |
 | `show_databases` | 查看所有数据库            |
-| `show_tables`    | 查看表列表 (支持模糊搜索) |
+| `show_tables`    | 查看表列表（支持模糊搜索） |
 | `describe_table` | 查看表结构信息            |
 
 ### Stage 管理
@@ -186,7 +232,7 @@ uv tool run mcp-databend
 | ------------------ | ---------------------------- |
 | `show_stages`      | 查看所有 Stage               |
 | `list_stage_files` | 列出 Stage 文件              |
-| `create_stage`     | 创建 Stage (支持 Connection) |
+| `create_stage`     | 创建 Stage（支持 Connection） |
 
 ### 连接管理
 
@@ -196,10 +242,10 @@ uv tool run mcp-databend
 
 ## 参数配置
 
-| 变量                     | 说明                                   | 默认值 |
-| ------------------------ | -------------------------------------- | ------ |
-| `DATABEND_DSN`           | 连接字符串 (DSN)                       | 必填   |
-| `SAFE_MODE`              | 安全模式 (禁止 DROP/DELETE 等高危操作) | `true` |
-| `DATABEND_QUERY_TIMEOUT` | 查询超时 (秒)                          | `300`  |
+| 变量                     | 说明                         | 默认值 |
+| ------------------------ | ---------------------------- | ------ |
+| `DATABEND_DSN`           | Databend 连接字符串（DSN）   | 必填   |
+| `DATABEND_MCP_SAFE_MODE` | 为 AI 工具启用会话沙箱防护   | `true` |
+| `DATABEND_QUERY_TIMEOUT` | 查询超时（秒）               | `300`  |
 
 更多关于构建对话式 BI 工具的内容，请参阅 [MCP Server 指南](02-mcp.md)。

--- a/docs/en/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/en/guides/51-ai-functions/03-mcp-integration.md
@@ -9,32 +9,39 @@ import TabItem from '@theme/TabItem';
 
 ## Overview
 
-[Databend MCP](https://github.com/databendlabs/mcp-databend) connects AI assistants to Databend via Model Context Protocol. Works with Claude Code, Codex, Cursor, Claude Desktop, VS Code, and other MCP-compatible clients.
+[Databend MCP](https://github.com/databendlabs/mcp-databend) connects AI assistants to Databend through the Model Context Protocol. It works with Codex, Kimi Code, Cursor, Claude Code, Claude Desktop, Gemini CLI, VS Code, and other MCP-compatible clients.
 
 **What you can do:**
 
-- Generate complex SQL queries based on your requirements
-- Create and manage scheduled data pipeline tasks
-- Explore database schemas and validate query syntax
-- Build ETL workflows with COPY, MERGE, and Stage operations
+- Generate complex SQL queries from natural language requirements.
+- Explore databases, tables, schemas, stages, and connections.
+- Validate query syntax before running it.
+- Build ETL workflows with COPY, MERGE, and Stage operations.
+- Create and manage scheduled data pipeline tasks.
 
-For example: _"Create a scheduled task that copies parquet files from @my_stage to the orders table every minute, and verify it's running correctly."_
+For example: _"Create a scheduled task that copies parquet files from @my_stage to the orders table every minute, and verify that it is running correctly."_
 
 ## Installation
 
-### 1. Get Databend Connection
+### 1. Get a Databend Connection
 
 We recommend using **Databend Cloud** for the best experience.
 
-1.  Log in to [Databend Cloud](https://app.databend.com).
-2.  Click **Use with AI Tools** in the navigation bar.
-3.  Select regular connection information (Host, User, Password, etc.).
-4.  Copy your DSN, which looks like:
-    `databend://user:pwd@host:443/database?warehouse=warehouse_name`
+1. Log in to [Databend Cloud](https://app.databend.com).
+2. Click **Use with AI Tools**.
+3. Choose the database and warehouse for the MCP server.
+4. Keep **Session Sandbox Safety** enabled unless you explicitly need the agent to write to production objects.
+5. Copy the DSN, which looks like:
+
+   ```text
+   databend://user:password@host:443/database?warehouse=warehouse_name
+   ```
 
 ![Use with AI Tools](@site/static/img/connect/ai-tools.png)
 
 ### 2. Configure Your MCP Client
+
+Use `DATABEND_MCP_SAFE_MODE=true` by default. In safe mode, production data remains read-only for AI agents, while write operations are scoped to session sandbox objects.
 
 <Tabs groupId="mcp-clients">
 
@@ -42,9 +49,9 @@ We recommend using **Databend Cloud** for the best experience.
 
 ```bash
 codex mcp add databend \
-  --env DATABEND_DSN='databend://user:password@host:port/database?warehouse=your_warehouse' \
-  --env SAFE_MODE='false' \
-  -- uv tool run mcp-databend
+  --env DATABEND_DSN='databend://user:password@host:443/database?warehouse=your_warehouse' \
+  --env DATABEND_MCP_SAFE_MODE=true \
+  -- uv tool run --from mcp-databend@latest mcp-databend
 ```
 
 Or add to `~/.codex/config.toml`:
@@ -52,11 +59,11 @@ Or add to `~/.codex/config.toml`:
 ```toml
 [mcp_servers.databend]
 command = "uv"
-args = ["tool", "run", "mcp-databend"]
+args = ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"]
 
 [mcp_servers.databend.env]
-DATABEND_DSN = "databend://user:password@host:port/database?warehouse=your_warehouse"
-SAFE_MODE = "false"
+DATABEND_DSN = "databend://user:password@host:443/database?warehouse=your_warehouse"
+DATABEND_MCP_SAFE_MODE = "true"
 ```
 
 </TabItem>
@@ -65,26 +72,33 @@ SAFE_MODE = "false"
 
 ```bash
 claude mcp add databend \
-  --env DATABEND_DSN='databend://user:password@host:port/database?warehouse=your_warehouse' \
-  --env SAFE_MODE='false' \
-  -- uv tool run mcp-databend
+  --env DATABEND_DSN='databend://user:password@host:443/database?warehouse=your_warehouse' \
+  --env DATABEND_MCP_SAFE_MODE=true \
+  -- uv tool run --from mcp-databend@latest mcp-databend
 ```
 
 </TabItem>
 
-<TabItem value="gemini-cli" label="Gemini CLI">
+<TabItem value="kimi-code" label="Kimi Code">
 
-Add to `~/.gemini/settings.json`:
+```bash
+kimi mcp add --transport stdio databend \
+  --env DATABEND_DSN='databend://user:password@host:443/database?warehouse=your_warehouse' \
+  --env DATABEND_MCP_SAFE_MODE=true \
+  -- uv tool run --from mcp-databend@latest mcp-databend
+```
+
+Or add to `~/.kimi/mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "databend": {
       "command": "uv",
-      "args": ["tool", "run", "mcp-databend"],
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
       "env": {
-        "DATABEND_DSN": "databend://user:password@host:port/database?warehouse=your_warehouse",
-        "SAFE_MODE": "false"
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
       }
     }
   }
@@ -102,10 +116,31 @@ Add to `~/.cursor/mcp.json`:
   "mcpServers": {
     "databend": {
       "command": "uv",
-      "args": ["tool", "run", "mcp-databend"],
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
       "env": {
-        "DATABEND_DSN": "databend://user:password@host:port/database?warehouse=your_warehouse",
-        "SAFE_MODE": "false"
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="gemini-cli" label="Gemini CLI">
+
+Add to `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "databend": {
+      "command": "uv",
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
+      "env": {
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
       }
     }
   }
@@ -116,17 +151,17 @@ Add to `~/.cursor/mcp.json`:
 
 <TabItem value="claude-desktop" label="Claude Desktop">
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%/Claude/claude_desktop_config.json` (Windows):
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, or `%APPDATA%\Claude\claude_desktop_config.json` on Windows:
 
 ```json
 {
   "mcpServers": {
     "databend": {
       "command": "uv",
-      "args": ["tool", "run", "mcp-databend"],
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
       "env": {
-        "DATABEND_DSN": "databend://user:password@host:port/database?warehouse=your_warehouse",
-        "SAFE_MODE": "false"
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
       }
     }
   }
@@ -137,17 +172,17 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 
 <TabItem value="vscode" label="VS Code">
 
-Add to `.vscode/mcp.json`:
+Open **Preferences: Open User Settings (JSON)** and add:
 
 ```json
 {
-  "mcpServers": {
+  "mcp.servers": {
     "databend": {
       "command": "uv",
-      "args": ["tool", "run", "mcp-databend"],
+      "args": ["tool", "run", "--from", "mcp-databend@latest", "mcp-databend"],
       "env": {
-        "DATABEND_DSN": "databend://user:password@host:port/database?warehouse=your_warehouse",
-        "SAFE_MODE": "false"
+        "DATABEND_DSN": "databend://user:password@host:443/database?warehouse=your_warehouse",
+        "DATABEND_MCP_SAFE_MODE": "true"
       }
     }
   }
@@ -159,15 +194,26 @@ Add to `.vscode/mcp.json`:
 <TabItem value="manual" label="Manual">
 
 ```bash
-export DATABEND_DSN="databend://user:password@host:port/database?warehouse=your_warehouse"
-export SAFE_MODE="false"
+export DATABEND_DSN="databend://user:password@host:443/database?warehouse=your_warehouse"
+export DATABEND_MCP_SAFE_MODE=true
 
-uv tool run mcp-databend
+uv tool run --from mcp-databend@latest mcp-databend
 ```
 
 </TabItem>
 
 </Tabs>
+
+## Session Sandbox Safety
+
+`DATABEND_MCP_SAFE_MODE` controls whether the MCP server runs with session sandbox protection.
+
+| Value | Behavior | Recommended usage |
+| ----- | -------- | ----------------- |
+| `true` | Production objects are read-only for the agent. Write operations are allowed only on session sandbox objects such as `mcp_sandbox_{session_id}_*`. | Default and recommended for AI tools. |
+| `false` | The MCP server can write to objects allowed by the Databend user permissions. | Use only with trusted agents and least-privilege Databend users. |
+
+Keep safe mode enabled for most workflows. Disable it only when the agent must modify real production objects and the Databend user already has the minimum required permissions.
 
 ## Available Tools
 
@@ -177,7 +223,7 @@ uv tool run mcp-databend
 | ---------------- | ------------------------------------------------ |
 | `execute_sql`    | Execute SQL queries with timeout protection      |
 | `show_databases` | List all databases                               |
-| `show_tables`    | List tables in a database (with optional filter) |
+| `show_tables`    | List tables in a database with optional filter   |
 | `describe_table` | Get table schema information                     |
 
 ### Stage Management
@@ -196,10 +242,10 @@ uv tool run mcp-databend
 
 ## Configuration
 
-| Variable                 | Description                                             | Default  |
-| ------------------------ | ------------------------------------------------------- | -------- |
-| `DATABEND_DSN`           | Connection string                                       | Required |
-| `SAFE_MODE`              | Block dangerous SQL operations (`DROP`, `DELETE`, etc.) | `true`   |
-| `DATABEND_QUERY_TIMEOUT` | Query timeout in seconds                                | `300`    |
+| Variable                 | Description                                    | Default  |
+| ------------------------ | ---------------------------------------------- | -------- |
+| `DATABEND_DSN`           | Databend connection string                     | Required |
+| `DATABEND_MCP_SAFE_MODE` | Enable session sandbox protection for AI tools | `true`   |
+| `DATABEND_QUERY_TIMEOUT` | Query timeout in seconds                       | `300`    |
 
 For more details on building conversational BI tools, see [MCP Server Guide](02-mcp.md).


### PR DESCRIPTION
## Summary
- add Kimi Code and refresh the MCP client examples
- use uv tool run --from mcp-databend@latest consistently
- document DATABEND_MCP_SAFE_MODE and session sandbox behavior
- update both English and Chinese guides

## Validation
- checked Markdown code fences and Tabs/TabItem balance
- git diff --check

Typecheck was not run locally because node_modules is not installed in this checkout.