### PR TITLE
docs: add schema evolution guide

### DIFF
--- a/docs/cn/guides/10-cloud/02-resources/warehouses.md
+++ b/docs/cn/guides/10-cloud/02-resources/warehouses.md
@@ -225,7 +225,25 @@ databend://<username>:<password>@<tenant>.gw.<region>.default.databend.com:443/<
 
 ### 创建 SQL 用户
 
-除默认的 `cloudapp` 用户外，您可以创建额外的 SQL 用户以实现更细粒度的安全管控：
+除默认的 `cloudapp` 用户外，您可以创建额外的 SQL 用户以实现更细粒度的安全管控。
+
+#### 示例 1：全库读写访问
+
+授予用户对所有数据库的读写权限，适用于需要跨库操作的管理账号或自动化流水线：
+
+```sql
+-- 创建全局访问角色
+CREATE ROLE full_access_role;
+GRANT ALL ON *.* TO ROLE full_access_role;
+
+-- 创建用户并分配角色
+CREATE USER admin_user IDENTIFIED BY 'SecurePass456!' WITH DEFAULT_ROLE = 'full_access_role';
+GRANT ROLE full_access_role TO admin_user;
+```
+
+#### 示例 2：单数据库访问
+
+仅授予用户对某个数据库的访问权限：
 
 ```sql
 -- 创建包含数据库权限的角色
@@ -236,6 +254,24 @@ GRANT ALL ON my_database.* TO ROLE warehouse_user1_role;
 CREATE USER warehouse_user1 IDENTIFIED BY 'StrongPassword123' WITH DEFAULT_ROLE = 'warehouse_user1_role';
 GRANT ROLE warehouse_user1_role TO warehouse_user1;
 ```
+
+#### 示例 3：全库只读访问
+
+适用于仅需查询数据的场景（仪表盘、BI 工具、安全模式下的 AI Agent）：
+
+```sql
+-- 创建只读角色
+CREATE ROLE readonly_role;
+GRANT SELECT ON *.* TO ROLE readonly_role;
+
+-- 创建用户
+CREATE USER readonly_user IDENTIFIED BY 'ReadOnly789!' WITH DEFAULT_ROLE = 'readonly_role';
+GRANT ROLE readonly_role TO readonly_user;
+```
+
+:::tip
+在 Databend Cloud 中，`CREATE DATABASE` 等权限只能授予角色，不能直接授予用户。请先创建角色、授权，再将角色分配给用户。
+:::
 
 更多详情请参阅 [CREATE USER](/sql/sql-commands/ddl/user/user-create-user) 和 [GRANT](/sql/sql-commands/ddl/user/grant) 文档。
 

--- a/docs/cn/guides/40-load-data/04-transform/07-schema-evolution.md
+++ b/docs/cn/guides/40-load-data/04-transform/07-schema-evolution.md
@@ -1,0 +1,125 @@
+---
+title: Schema Evolution
+description: 在使用 COPY INTO 加载数据时自动演进表结构。
+sidebar_label: Schema Evolution
+---
+
+# Schema Evolution
+
+Schema Evolution 允许 Databend 在 `COPY INTO` 加载数据时，自动将源 Parquet 文件中存在但表中缺失的列添加到目标表。
+
+## 工作原理
+
+启用后，`COPY INTO` 会：
+
+1. 从源 Parquet 文件推断 schema。
+2. 将新列（表中不存在的）作为可空列添加到表中。
+3. 加载数据，缺失的值用 `NULL` 填充。
+
+## 启用 Schema Evolution
+
+将表选项 `ENABLE_SCHEMA_EVOLUTION` 设置为 `true`：
+
+```sql
+-- 对已有表启用
+ALTER TABLE my_table SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);
+
+-- 或在建表时启用
+CREATE TABLE my_table(id INT) ENABLE_SCHEMA_EVOLUTION = true;
+```
+
+如需禁用，设回 `false`：
+
+```sql
+ALTER TABLE my_table SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = false);
+```
+
+## 教程
+
+以下是一个完整可运行的示例。
+
+### 步骤 1：创建表和 Stage
+
+```sql
+CREATE OR REPLACE TABLE invoices(order_id INT);
+CREATE OR REPLACE STAGE my_stage;
+```
+
+### 步骤 2：生成不同 Schema 的 Parquet 文件
+
+```sql
+-- 文件包含列：order_id, amount, currency
+COPY INTO @my_stage FROM (
+    SELECT 1 AS order_id, 100.50::DOUBLE AS amount, 'USD' AS currency
+    UNION ALL
+    SELECT 2, 250.50::DOUBLE, 'EUR'
+) FILE_FORMAT = (TYPE = parquet);
+
+-- 文件包含列：order_id, amount（无 currency）
+COPY INTO @my_stage FROM (
+    SELECT 3 AS order_id, 75.50::DOUBLE AS amount
+) FILE_FORMAT = (TYPE = parquet);
+```
+
+### 步骤 3：启用 Schema Evolution 并加载
+
+```sql
+ALTER TABLE invoices SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);
+
+COPY INTO invoices
+FROM @my_stage/
+FILE_FORMAT = (TYPE = parquet MISSING_FIELD_AS = FIELD_DEFAULT);
+```
+
+### 步骤 4：验证结果
+
+表现在有三列 — `amount` 和 `currency` 被自动添加：
+
+```sql
+DESC invoices;
+```
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│   Field  │      Type      │  Null  │ Default │    Extra     │
+├──────────┼────────────────┼────────┼─────────┼──────────────┤
+│ order_id │ INT            │ YES    │ NULL    │              │
+│ amount   │ DOUBLE         │ YES    │ NULL    │              │
+│ currency │ VARCHAR        │ YES    │ NULL    │              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+```sql
+SELECT * FROM invoices ORDER BY order_id;
+```
+
+```text
+┌──────────────────────────────────────────────────┐
+│ order_id │  amount  │ currency                    │
+├──────────┼──────────┼─────────────────────────────┤
+│        1 │   100.50 │ USD                         │
+│        2 │   250.50 │ EUR                         │
+│        3 │    75.50 │ NULL                        │
+└──────────────────────────────────────────────────┘
+```
+
+第 3 行的 `currency = NULL`，因为其源文件中不包含该列。
+
+## 列匹配模式
+
+默认按不区分大小写匹配列名。使用 `COLUMN_MATCH_MODE` 可启用大小写敏感匹配：
+
+```sql
+COPY INTO invoices
+FROM @my_stage/
+FILE_FORMAT = (TYPE = parquet MISSING_FIELD_AS = FIELD_DEFAULT)
+COLUMN_MATCH_MODE = CASE_SENSITIVE;
+```
+
+## 限制
+
+- 仅支持 **Parquet** 文件。
+- 新列追加到表末尾，始终为可空类型。
+- 如果同名列在多个文件中具有**不同数据类型**，加载将失败。
+- 不会自动提升类型（如 `INT` → `BIGINT`）。
+- 不支持通过 Schema Evolution 删除或重命名列。

--- a/docs/cn/guides/40-load-data/04-transform/index.md
+++ b/docs/cn/guides/40-load-data/04-transform/index.md
@@ -154,3 +154,6 @@ SELECT METADATA$FILENAME, METADATA$FILE_ROW_NUMBER, $1, <FROM Clause>
 - [查询 Avro 文件](./04-querying-avro.md)
 - [查询 CSV 文件](./01-querying-csv.md)
 - [查询 TSV 文件](./02-querying-tsv.md)
+
+## Schema Evolution
+- [Schema Evolution](./07-schema-evolution.md) — 加载 Parquet 文件时自动向表中添加新列。

--- a/docs/cn/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/cn/guides/51-ai-functions/03-mcp-integration.md
@@ -47,7 +47,7 @@ import TabItem from '@theme/TabItem';
 
 如果你希望使用固定的账号和权限（例如 CI 环境、共享给团队成员，或搭配最小权限策略），可以自行创建 SQL 用户并拼接 DSN。
 
-1. 在 Databend Cloud 中 [创建 SQL 用户](/guides/cloud/resources/warehouses#creating-sql-users-for-warehouse-access) 并授予所需权限。
+1. 在 Databend Cloud 中创建 SQL 用户并授予所需权限，参阅 [CREATE USER](/sql/sql-commands/ddl/user/user-create-user) 和 [GRANT](/sql/sql-commands/ddl/user/grant)。
 2. 从 **概览 → 连接** 页面获取 `tenant`、`region`、`database`、`warehouse` 等信息。
 3. 按下列格式拼接 DSN：
 

--- a/docs/cn/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/cn/guides/51-ai-functions/03-mcp-integration.md
@@ -25,7 +25,11 @@ import TabItem from '@theme/TabItem';
 
 ### 1. 获取 Databend 连接信息
 
-推荐使用 **Databend Cloud** 以获得开箱即用的体验。
+推荐使用 **Databend Cloud** 以获得开箱即用的体验。你有两种方式获取 DSN。
+
+#### 方式 A：使用 **与 AI 工具连接**（推荐）
+
+一键生成带会话沙箱防护的临时 DSN，适合快速接入 AI 工具。
 
 1. 登录 [Databend Cloud](https://app.databend.cn)。
 2. 点击 **与 AI 工具连接**。
@@ -38,6 +42,20 @@ import TabItem from '@theme/TabItem';
    ```
 
 ![与 AI 工具连接](@site/static/img/connect/ai-tools.png)
+
+#### 方式 B：使用自建 SQL 用户拼接 DSN
+
+如果你希望使用固定的账号和权限（例如 CI 环境、共享给团队成员，或搭配最小权限策略），可以自行创建 SQL 用户并拼接 DSN。
+
+1. 在 Databend Cloud 中 [创建 SQL 用户](/guides/cloud/resources/warehouses#creating-sql-users-for-warehouse-access) 并授予所需权限。
+2. 从 **概览 → 连接** 页面获取 `tenant`、`region`、`database`、`warehouse` 等信息。
+3. 按下列格式拼接 DSN：
+
+   ```text
+   databend://<username>:<password>@<tenant>.gw.<region>.default.databend.com:443/<database>?warehouse=<warehouse_name>
+   ```
+
+自建用户不会自动启用会话沙箱，建议通过最小权限控制写入范围，并在下一步保持 `DATABEND_MCP_SAFE_MODE=true`。
 
 ### 2. 配置 MCP 客户端
 

--- a/docs/cn/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/cn/guides/51-ai-functions/03-mcp-integration.md
@@ -47,7 +47,7 @@ import TabItem from '@theme/TabItem';
 
 如果你希望使用固定的账号和权限（例如 CI 环境、共享给团队成员，或搭配最小权限策略），可以自行创建 SQL 用户并拼接 DSN。
 
-1. 在 Databend Cloud 中创建 SQL 用户并授予所需权限，参阅 [CREATE USER](/sql/sql-commands/ddl/user/user-create-user) 和 [GRANT](/sql/sql-commands/ddl/user/grant)。
+1. 在 Databend Cloud 中创建 SQL 用户并授予所需权限，参阅[创建 SQL 用户](/guides/cloud/resources/warehouses#创建-sql-用户)。
 2. 从 **概览 → 连接** 页面获取 `tenant`、`region`、`database`、`warehouse` 等信息。
 3. 按下列格式拼接 DSN：
 

--- a/docs/cn/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/cn/guides/51-ai-functions/03-mcp-integration.md
@@ -47,7 +47,7 @@ import TabItem from '@theme/TabItem';
 
 如果你希望使用固定的账号和权限（例如 CI 环境、共享给团队成员，或搭配最小权限策略），可以自行创建 SQL 用户并拼接 DSN。
 
-1. 在 Databend Cloud 中创建 SQL 用户并授予所需权限，参阅 [CREATE USER](/sql/sql-commands/ddl/user/user-create-user#示例-4为-ai-工具或自动化创建全权限用户)。
+1. 在 Databend Cloud 中创建 SQL 用户并授予所需权限，参阅 [CREATE USER](/sql/sql-commands/ddl/user/user-create-user#示例-1全库读写访问)。
 2. 从 **概览 → 连接** 页面获取 `tenant`、`region`、`database`、`warehouse` 等信息。
 3. 按下列格式拼接 DSN：
 

--- a/docs/cn/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/cn/guides/51-ai-functions/03-mcp-integration.md
@@ -47,7 +47,7 @@ import TabItem from '@theme/TabItem';
 
 如果你希望使用固定的账号和权限（例如 CI 环境、共享给团队成员，或搭配最小权限策略），可以自行创建 SQL 用户并拼接 DSN。
 
-1. 在 Databend Cloud 中创建 SQL 用户并授予所需权限，参阅[创建 SQL 用户](/guides/cloud/resources/warehouses#创建-sql-用户)。
+1. 在 Databend Cloud 中创建 SQL 用户并授予所需权限，参阅 [CREATE USER](/sql/sql-commands/ddl/user/user-create-user#示例-4为-ai-工具或自动化创建全权限用户)。
 2. 从 **概览 → 连接** 页面获取 `tenant`、`region`、`database`、`warehouse` 等信息。
 3. 按下列格式拼接 DSN：
 

--- a/docs/cn/sql-reference/00-sql-reference/30-table-engines/00-fuse.md
+++ b/docs/cn/sql-reference/00-sql-reference/30-table-engines/00-fuse.md
@@ -239,3 +239,22 @@ CREATE TABLE <table_name> (
   ```
 
 ---
+
+### `enable_schema_evolution`
+
+- **语法：**
+  `enable_schema_evolution = True / False`
+- **描述：**
+  控制表在 `COPY INTO` 操作中是否可以自动演进结构。启用后（设置为 `True`），当加载的 Parquet 文件结构包含目标表中不存在的列时，Databend 会自动将这些缺失的列添加到表中。已有行的缺失值将用 `NULL` 填充。更多信息请参阅 [Schema Evolution](/guides/load-data/transform/schema-evolution)。
+
+  **示例：**
+
+  ```sql
+  -- 为现有表启用 Schema Evolution
+  ALTER TABLE invoices SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);
+
+  -- 创建新表时启用 Schema Evolution
+  CREATE OR REPLACE TABLE invoices (order_id INT) ENABLE_SCHEMA_EVOLUTION = true;
+  ```
+
+---

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/01-table/90-alter-table.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/01-table/90-alter-table.md
@@ -162,6 +162,7 @@ ALTER TABLE [ <database_name>. ]<table_name> UNSET OPTIONS (<options>)
 - `block_size_threshold`
 - `data_retention_period_in_hours`
 - `data_retention_num_snapshots_to_keep`
+- `enable_schema_evolution`
 - `row_avg_depth_threshold`
 - `row_per_block`
 - `row_per_page`

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
@@ -33,7 +33,35 @@ CREATE [ OR REPLACE ] USER <name> IDENTIFIED [ WITH <auth_type> ] BY '<password>
 
 ## 示例
 
-### 示例 1：创建用户并授予数据库权限
+### 示例 1：全库读写访问
+
+创建拥有所有数据库读写权限的用户：
+
+```sql
+-- 创建全局访问角色
+CREATE ROLE full_access_role;
+GRANT ALL ON *.* TO ROLE full_access_role;
+
+-- 创建用户并分配角色
+CREATE USER admin_user IDENTIFIED BY 'SecurePass456!' WITH DEFAULT_ROLE = 'full_access_role';
+GRANT ROLE full_access_role TO admin_user;
+```
+
+### 示例 2：全库只读访问
+
+创建仅能查询数据的用户，适用于仪表盘或 BI 工具：
+
+```sql
+-- 创建只读角色
+CREATE ROLE readonly_role;
+GRANT SELECT ON *.* TO ROLE readonly_role;
+
+-- 创建用户
+CREATE USER readonly_user IDENTIFIED BY 'ReadOnly789!' WITH DEFAULT_ROLE = 'readonly_role';
+GRANT ROLE readonly_role TO readonly_user;
+```
+
+### 示例 3：单数据库访问
 
 创建角色并授予数据库权限，然后将角色授予用户：
 
@@ -57,32 +85,7 @@ SHOW GRANTS FOR ROLE data_analyst_role;
 +----------------------------------------------------------------+
 ```
 
-### 示例 2：创建用户并授予角色
-
-创建用户并分配具有特定权限的角色：
-
-```sql
--- 创建角色并授予权限
-CREATE ROLE analyst_role;
-GRANT SELECT ON *.* TO ROLE analyst_role;
-GRANT INSERT ON default.* TO ROLE analyst_role;
-
--- 创建用户并授予角色
-CREATE USER john_analyst IDENTIFIED BY 'secure_pass456';
-GRANT ROLE analyst_role TO john_analyst;
-```
-
-验证角色分配：
-```sql
-SHOW GRANTS FOR john_analyst;
-+------------------------------------------+
-| Grants                                   |
-+------------------------------------------+
-| GRANT ROLE analyst_role TO 'john_analyst'@'%' |
-+------------------------------------------+
-```
-
-### 示例 3：创建不同认证类型的用户
+### 示例 4：创建不同认证类型的用户
 
 ```sql
 -- 使用默认认证创建用户
@@ -90,32 +93,4 @@ CREATE USER user1 IDENTIFIED BY 'abc123';
 
 -- 使用 SHA256 认证创建用户
 CREATE USER user2 IDENTIFIED WITH sha256_password BY 'abc123';
-```
-
-### 示例 4：为 AI 工具或自动化创建全权限用户
-
-创建拥有所有数据库读写权限的用户，适用于管理账号或自动化流水线：
-
-```sql
--- 创建全局访问角色
-CREATE ROLE full_access_role;
-GRANT ALL ON *.* TO ROLE full_access_role;
-
--- 创建用户并分配角色
-CREATE USER admin_user IDENTIFIED BY 'SecurePass456!' WITH DEFAULT_ROLE = 'full_access_role';
-GRANT ROLE full_access_role TO admin_user;
-```
-
-### 示例 5：全库只读用户
-
-创建仅能查询数据的用户，适用于仪表盘、BI 工具或安全模式下的 AI Agent：
-
-```sql
--- 创建只读角色
-CREATE ROLE readonly_role;
-GRANT SELECT ON *.* TO ROLE readonly_role;
-
--- 创建用户
-CREATE USER readonly_user IDENTIFIED BY 'ReadOnly789!' WITH DEFAULT_ROLE = 'readonly_role';
-GRANT ROLE readonly_role TO readonly_user;
 ```

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
@@ -92,16 +92,30 @@ CREATE USER user1 IDENTIFIED BY 'abc123';
 CREATE USER user2 IDENTIFIED WITH sha256_password BY 'abc123';
 ```
 
-### 示例 4：创建具有特殊配置的用户
+### 示例 4：为 AI 工具或自动化创建全权限用户
+
+创建拥有所有数据库读写权限的用户，适用于管理账号或自动化流水线：
 
 ```sql
--- 创建需修改密码的用户
-CREATE USER new_employee IDENTIFIED BY 'temp123' WITH MUST_CHANGE_PASSWORD = true;
+-- 创建全局访问角色
+CREATE ROLE full_access_role;
+GRANT ALL ON *.* TO ROLE full_access_role;
 
--- 创建禁用状态的用户
-CREATE USER temp_user IDENTIFIED BY 'abc123' WITH DISABLED = true;
+-- 创建用户并分配角色
+CREATE USER admin_user IDENTIFIED BY 'SecurePass456!' WITH DEFAULT_ROLE = 'full_access_role';
+GRANT ROLE full_access_role TO admin_user;
+```
 
--- 创建带默认角色的用户（需单独授予角色）
-CREATE USER manager IDENTIFIED BY 'abc123' WITH DEFAULT_ROLE = 'admin';
-GRANT ROLE admin TO manager;
+### 示例 5：全库只读用户
+
+创建仅能查询数据的用户，适用于仪表盘、BI 工具或安全模式下的 AI Agent：
+
+```sql
+-- 创建只读角色
+CREATE ROLE readonly_role;
+GRANT SELECT ON *.* TO ROLE readonly_role;
+
+-- 创建用户
+CREATE USER readonly_user IDENTIFIED BY 'ReadOnly789!' WITH DEFAULT_ROLE = 'readonly_role';
+GRANT ROLE readonly_role TO readonly_user;
 ```

--- a/docs/cn/sql-reference/10-sql-commands/10-dml/dml-copy-into-table.md
+++ b/docs/cn/sql-reference/10-sql-commands/10-dml/dml-copy-into-table.md
@@ -706,3 +706,25 @@ SELECT * FROM t2;
 │ 6                │ null              │
 └──────────────────────────────────────┘
 ```
+
+### 示例 8：使用 Schema Evolution 加载
+
+当加载的 Parquet 文件结构包含目标表中不存在的列时，可以使用 Schema Evolution 自动添加缺失的列。首先，在表上启用 Schema Evolution：
+
+```sql
+CREATE OR REPLACE TABLE invoices(order_id INT);
+
+-- 启用 Schema Evolution
+ALTER TABLE invoices SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);
+```
+
+然后加载具有不同结构的 Parquet 文件。Databend 会自动添加新列，缺失的值用 `NULL` 填充：
+
+```sql
+-- 假设 @my_stage 中包含带有额外列（如 amount、currency）的 Parquet 文件
+COPY INTO invoices
+    FROM @my_stage/
+    FILE_FORMAT = (TYPE = PARQUET MISSING_FIELD_AS = FIELD_DEFAULT);
+```
+
+更多详细信息，请参阅 [Schema Evolution](/guides/load-data/transform/schema-evolution)。

--- a/docs/en/guides/10-cloud/02-resources/warehouses.md
+++ b/docs/en/guides/10-cloud/02-resources/warehouses.md
@@ -225,10 +225,28 @@ Where:
 
 ### Creating SQL Users for Warehouse Access
 
-Besides the default `cloudapp` user, you can create additional SQL users for better security and access control:
+Besides the default `cloudapp` user, you can create additional SQL users for better security and access control.
+
+#### Example 1: Full access across all databases
+
+Grant a user read/write access to all databases — useful for admin accounts or automation pipelines that need cross-database operations:
 
 ```sql
--- Create a role with database access
+-- Create a role with global access
+CREATE ROLE full_access_role;
+GRANT ALL ON *.* TO ROLE full_access_role;
+
+-- Create the user and assign the role
+CREATE USER admin_user IDENTIFIED BY 'SecurePass456!' WITH DEFAULT_ROLE = 'full_access_role';
+GRANT ROLE full_access_role TO admin_user;
+```
+
+#### Example 2: Single-database access
+
+Grant a user access to one specific database only:
+
+```sql
+-- Create a role scoped to one database
 CREATE ROLE warehouse_user1_role;
 GRANT ALL ON my_database.* TO ROLE warehouse_user1_role;
 
@@ -236,6 +254,24 @@ GRANT ALL ON my_database.* TO ROLE warehouse_user1_role;
 CREATE USER warehouse_user1 IDENTIFIED BY 'StrongPassword123' WITH DEFAULT_ROLE = 'warehouse_user1_role';
 GRANT ROLE warehouse_user1_role TO warehouse_user1;
 ```
+
+#### Example 3: Read-only access across all databases
+
+For scenarios where the user should only query data (dashboards, BI tools, AI agents in safe mode):
+
+```sql
+-- Create a read-only role
+CREATE ROLE readonly_role;
+GRANT SELECT ON *.* TO ROLE readonly_role;
+
+-- Create the user
+CREATE USER readonly_user IDENTIFIED BY 'ReadOnly789!' WITH DEFAULT_ROLE = 'readonly_role';
+GRANT ROLE readonly_role TO readonly_user;
+```
+
+:::tip
+In Databend Cloud, privileges like `CREATE DATABASE` can only be granted to roles, not directly to users. Always create a role first, grant privileges to the role, then assign the role to the user.
+:::
 
 For more details, see [CREATE USER](/sql/sql-commands/ddl/user/user-create-user) and [GRANT](/sql/sql-commands/ddl/user/grant) documentation.
 

--- a/docs/en/guides/40-load-data/04-transform/07-schema-evolution.md
+++ b/docs/en/guides/40-load-data/04-transform/07-schema-evolution.md
@@ -1,0 +1,125 @@
+---
+title: Schema Evolution
+description: Automatically evolve table schemas when loading data with COPY INTO.
+sidebar_label: Schema Evolution
+---
+
+# Schema Evolution
+
+Schema evolution allows Databend to automatically add new columns to a table during `COPY INTO` when the source Parquet files contain columns not yet present in the table.
+
+## How It Works
+
+When enabled, `COPY INTO`:
+
+1. Infers the schema from source Parquet files.
+2. Adds any new columns (not in the table) as nullable columns.
+3. Loads the data, filling missing values with `NULL`.
+
+## Enabling Schema Evolution
+
+Set the table option `ENABLE_SCHEMA_EVOLUTION` to `true`:
+
+```sql
+-- On an existing table
+ALTER TABLE my_table SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);
+
+-- Or when creating a new table
+CREATE TABLE my_table(id INT) ENABLE_SCHEMA_EVOLUTION = true;
+```
+
+To disable, set it back to `false`:
+
+```sql
+ALTER TABLE my_table SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = false);
+```
+
+## Tutorial
+
+This tutorial uses a fully runnable example to demonstrate schema evolution.
+
+### Step 1: Create a Table and Stage
+
+```sql
+CREATE OR REPLACE TABLE invoices(order_id INT);
+CREATE OR REPLACE STAGE my_stage;
+```
+
+### Step 2: Generate Parquet Files with Different Schemas
+
+```sql
+-- File with columns: order_id, amount, currency
+COPY INTO @my_stage FROM (
+    SELECT 1 AS order_id, 100.50::DOUBLE AS amount, 'USD' AS currency
+    UNION ALL
+    SELECT 2, 250.50::DOUBLE, 'EUR'
+) FILE_FORMAT = (TYPE = parquet);
+
+-- File with columns: order_id, amount (no currency)
+COPY INTO @my_stage FROM (
+    SELECT 3 AS order_id, 75.50::DOUBLE AS amount
+) FILE_FORMAT = (TYPE = parquet);
+```
+
+### Step 3: Enable Schema Evolution and Load
+
+```sql
+ALTER TABLE invoices SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);
+
+COPY INTO invoices
+FROM @my_stage/
+FILE_FORMAT = (TYPE = parquet MISSING_FIELD_AS = FIELD_DEFAULT);
+```
+
+### Step 4: Verify Results
+
+The table now has three columns — `amount` and `currency` were added automatically:
+
+```sql
+DESC invoices;
+```
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│   Field  │      Type      │  Null  │ Default │    Extra     │
+├──────────┼────────────────┼────────┼─────────┼──────────────┤
+│ order_id │ INT            │ YES    │ NULL    │              │
+│ amount   │ DOUBLE         │ YES    │ NULL    │              │
+│ currency │ VARCHAR        │ YES    │ NULL    │              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+```sql
+SELECT * FROM invoices ORDER BY order_id;
+```
+
+```text
+┌──────────────────────────────────────────────────┐
+│ order_id │  amount  │ currency                    │
+├──────────┼──────────┼─────────────────────────────┤
+│        1 │   100.50 │ USD                         │
+│        2 │   250.50 │ EUR                         │
+│        3 │    75.50 │ NULL                        │
+└──────────────────────────────────────────────────┘
+```
+
+Row 3 has `currency = NULL` because its source file did not contain that column.
+
+## Column Match Mode
+
+By default, column names are matched case-insensitively. Use `COLUMN_MATCH_MODE` for case-sensitive matching:
+
+```sql
+COPY INTO invoices
+FROM @my_stage/
+FILE_FORMAT = (TYPE = parquet MISSING_FIELD_AS = FIELD_DEFAULT)
+COLUMN_MATCH_MODE = CASE_SENSITIVE;
+```
+
+## Limitations
+
+- Supported for **Parquet** files only.
+- New columns are appended to the end of the table and are always nullable.
+- If the same column name appears in multiple files with **different data types**, the load fails.
+- No automatic type promotion (e.g., `INT` → `BIGINT`).
+- Column drops and renames are not supported through schema evolution.

--- a/docs/en/guides/40-load-data/04-transform/index.md
+++ b/docs/en/guides/40-load-data/04-transform/index.md
@@ -154,3 +154,6 @@ The following file-level metadata fields are available for the supported file fo
 - [Querying Avro Files](./04-querying-avro.md)
 - [Querying CSV Files](./01-querying-csv.md)
 - [Querying TSV Files](./02-querying-tsv.md)
+
+## Schema Evolution
+- [Schema Evolution](./07-schema-evolution.md) — Automatically add new columns to a table when loading Parquet files with evolving schemas.

--- a/docs/en/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/en/guides/51-ai-functions/03-mcp-integration.md
@@ -47,7 +47,7 @@ Generates a short-lived DSN with session sandbox safety in one click. Best for g
 
 Use this when you want a stable account and permission set (for example, CI pipelines, sharing with teammates, or pairing with a least-privilege policy).
 
-1. Create a SQL user in Databend Cloud and grant the required privileges. See [Creating SQL Users for Warehouse Access](/guides/cloud/resources/warehouses#creating-sql-users-for-warehouse-access).
+1. Create a SQL user in Databend Cloud and grant the required privileges. See [CREATE USER](/sql/sql-commands/ddl/user/user-create-user) and [GRANT](/sql/sql-commands/ddl/user/grant).
 2. Get your `tenant`, `region`, `database`, and `warehouse` values from **Overview → Connect**.
 3. Assemble the DSN using this format:
 

--- a/docs/en/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/en/guides/51-ai-functions/03-mcp-integration.md
@@ -47,7 +47,7 @@ Generates a short-lived DSN with session sandbox safety in one click. Best for g
 
 Use this when you want a stable account and permission set (for example, CI pipelines, sharing with teammates, or pairing with a least-privilege policy).
 
-1. Create a SQL user in Databend Cloud and grant the required privileges. See [CREATE USER](/sql/sql-commands/ddl/user/user-create-user) and [GRANT](/sql/sql-commands/ddl/user/grant).
+1. Create a SQL user in Databend Cloud and grant the required privileges. See [Creating SQL Users](/guides/cloud/resources/warehouses#creating-sql-users-for-warehouse-access).
 2. Get your `tenant`, `region`, `database`, and `warehouse` values from **Overview → Connect**.
 3. Assemble the DSN using this format:
 

--- a/docs/en/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/en/guides/51-ai-functions/03-mcp-integration.md
@@ -47,7 +47,7 @@ Generates a short-lived DSN with session sandbox safety in one click. Best for g
 
 Use this when you want a stable account and permission set (for example, CI pipelines, sharing with teammates, or pairing with a least-privilege policy).
 
-1. Create a SQL user in Databend Cloud and grant the required privileges. See [Creating SQL Users](/guides/cloud/resources/warehouses#creating-sql-users-for-warehouse-access).
+1. Create a SQL user in Databend Cloud and grant the required privileges. See [CREATE USER](/sql/sql-commands/ddl/user/user-create-user#example-4-full-access-for-ai-tools-or-automation).
 2. Get your `tenant`, `region`, `database`, and `warehouse` values from **Overview → Connect**.
 3. Assemble the DSN using this format:
 

--- a/docs/en/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/en/guides/51-ai-functions/03-mcp-integration.md
@@ -25,7 +25,11 @@ For example: _"Create a scheduled task that copies parquet files from @my_stage 
 
 ### 1. Get a Databend Connection
 
-We recommend using **Databend Cloud** for the best experience.
+We recommend using **Databend Cloud** for the best experience. You can obtain the DSN in two ways.
+
+#### Option A: Use **Use with AI Tools** (recommended)
+
+Generates a short-lived DSN with session sandbox safety in one click. Best for getting AI tools connected quickly.
 
 1. Log in to [Databend Cloud](https://app.databend.com).
 2. Click **Use with AI Tools**.
@@ -38,6 +42,20 @@ We recommend using **Databend Cloud** for the best experience.
    ```
 
 ![Use with AI Tools](@site/static/img/connect/ai-tools.png)
+
+#### Option B: Build the DSN with your own SQL user
+
+Use this when you want a stable account and permission set (for example, CI pipelines, sharing with teammates, or pairing with a least-privilege policy).
+
+1. Create a SQL user in Databend Cloud and grant the required privileges. See [Creating SQL Users for Warehouse Access](/guides/cloud/resources/warehouses#creating-sql-users-for-warehouse-access).
+2. Get your `tenant`, `region`, `database`, and `warehouse` values from **Overview → Connect**.
+3. Assemble the DSN using this format:
+
+   ```text
+   databend://<username>:<password>@<tenant>.gw.<region>.default.databend.com:443/<database>?warehouse=<warehouse_name>
+   ```
+
+Self-created users do not get the session sandbox automatically. Scope writes through least-privilege grants and keep `DATABEND_MCP_SAFE_MODE=true` in the next step.
 
 ### 2. Configure Your MCP Client
 

--- a/docs/en/guides/51-ai-functions/03-mcp-integration.md
+++ b/docs/en/guides/51-ai-functions/03-mcp-integration.md
@@ -47,7 +47,7 @@ Generates a short-lived DSN with session sandbox safety in one click. Best for g
 
 Use this when you want a stable account and permission set (for example, CI pipelines, sharing with teammates, or pairing with a least-privilege policy).
 
-1. Create a SQL user in Databend Cloud and grant the required privileges. See [CREATE USER](/sql/sql-commands/ddl/user/user-create-user#example-4-full-access-for-ai-tools-or-automation).
+1. Create a SQL user in Databend Cloud and grant the required privileges. See [CREATE USER](/sql/sql-commands/ddl/user/user-create-user#example-1-full-access-across-all-databases).
 2. Get your `tenant`, `region`, `database`, and `warehouse` values from **Overview → Connect**.
 3. Assemble the DSN using this format:
 

--- a/docs/en/sql-reference/00-sql-reference/30-table-engines/00-fuse.md
+++ b/docs/en/sql-reference/00-sql-reference/30-table-engines/00-fuse.md
@@ -223,3 +223,20 @@ Below are the available Fuse Engine options, grouped by their purpose:
   ```
 
 ---
+
+### `enable_schema_evolution`
+- **Syntax:**
+  `enable_schema_evolution = True / False`
+- **Description:**
+  Controls whether the table schema can be automatically evolved during `COPY INTO` operations. When enabled (set to `True`), Databend automatically adds missing columns to the table when loading Parquet files whose schemas contain columns not present in the destination table. Missing values for existing rows are filled with `NULL`. For more information, see [Schema Evolution](/guides/load-data/transform/schema-evolution).
+
+  **Examples:**
+  ```sql
+  -- Enable schema evolution for an existing table
+  ALTER TABLE invoices SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);
+
+  -- Create a new table with schema evolution enabled
+  CREATE OR REPLACE TABLE invoices (order_id INT) ENABLE_SCHEMA_EVOLUTION = true;
+  ```
+
+---

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/90-alter-table.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/01-table/90-alter-table.md
@@ -250,6 +250,7 @@ Only the following Fuse Engine options can be unset:
 - `block_size_threshold`
 - `data_retention_period_in_hours`
 - `data_retention_num_snapshots_to_keep`
+- `enable_schema_evolution`
 - `row_avg_depth_threshold`
 - `row_per_block`
 - `row_per_page`

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
@@ -33,7 +33,35 @@ CREATE [ OR REPLACE ] USER <name> IDENTIFIED [ WITH <auth_type> ] BY '<password>
 
 ## Examples
 
-### Example 1: Create User and Grant Database Privileges
+### Example 1: Full Access Across All Databases
+
+Create a user with full read/write access across all databases:
+
+```sql
+-- Create a role with global access
+CREATE ROLE full_access_role;
+GRANT ALL ON *.* TO ROLE full_access_role;
+
+-- Create the user and assign the role
+CREATE USER admin_user IDENTIFIED BY 'SecurePass456!' WITH DEFAULT_ROLE = 'full_access_role';
+GRANT ROLE full_access_role TO admin_user;
+```
+
+### Example 2: Read-Only Access Across All Databases
+
+Create a user that can only query data, suitable for dashboards or BI tools:
+
+```sql
+-- Create a read-only role
+CREATE ROLE readonly_role;
+GRANT SELECT ON *.* TO ROLE readonly_role;
+
+-- Create the user
+CREATE USER readonly_user IDENTIFIED BY 'ReadOnly789!' WITH DEFAULT_ROLE = 'readonly_role';
+GRANT ROLE readonly_role TO readonly_user;
+```
+
+### Example 3: Single-Database Access
 
 Create a role, grant database privileges, and assign the role to a user:
 
@@ -57,32 +85,7 @@ SHOW GRANTS FOR ROLE data_analyst_role;
 +-----------------------------------------------------------------+
 ```
 
-### Example 2: Create User and Grant Role
-
-Create a user and assign a role with specific privileges:
-
-```sql
--- Create a role with specific privileges
-CREATE ROLE analyst_role;
-GRANT SELECT ON *.* TO ROLE analyst_role;
-GRANT INSERT ON default.* TO ROLE analyst_role;
-
--- Create user and grant the role
-CREATE USER john_analyst IDENTIFIED BY 'secure_pass456';
-GRANT ROLE analyst_role TO john_analyst;
-```
-
-Verify the role assignment:
-```sql
-SHOW GRANTS FOR john_analyst;
-+------------------------------------------+
-| Grants                                   |
-+------------------------------------------+
-| GRANT ROLE analyst_role TO 'john_analyst'@'%' |
-+------------------------------------------+
-```
-
-### Example 3: Create Users with Different Authentication Types
+### Example 4: Create Users with Different Authentication Types
 
 ```sql
 -- Create user with default authentication
@@ -90,32 +93,4 @@ CREATE USER user1 IDENTIFIED BY 'abc123';
 
 -- Create user with SHA256 authentication
 CREATE USER user2 IDENTIFIED WITH sha256_password BY 'abc123';
-```
-
-### Example 4: Full Access for AI Tools or Automation
-
-Create a user with full read/write access across all databases, suitable for admin accounts or automation pipelines:
-
-```sql
--- Create a role with global access
-CREATE ROLE full_access_role;
-GRANT ALL ON *.* TO ROLE full_access_role;
-
--- Create the user and assign the role
-CREATE USER admin_user IDENTIFIED BY 'SecurePass456!' WITH DEFAULT_ROLE = 'full_access_role';
-GRANT ROLE full_access_role TO admin_user;
-```
-
-### Example 5: Read-Only Access Across All Databases
-
-Create a user that can only query data, suitable for dashboards, BI tools, or AI agents in safe mode:
-
-```sql
--- Create a read-only role
-CREATE ROLE readonly_role;
-GRANT SELECT ON *.* TO ROLE readonly_role;
-
--- Create the user
-CREATE USER readonly_user IDENTIFIED BY 'ReadOnly789!' WITH DEFAULT_ROLE = 'readonly_role';
-GRANT ROLE readonly_role TO readonly_user;
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/02-user/01-user-create-user.md
@@ -92,16 +92,30 @@ CREATE USER user1 IDENTIFIED BY 'abc123';
 CREATE USER user2 IDENTIFIED WITH sha256_password BY 'abc123';
 ```
 
-### Example 4: Create Users with Special Configurations
+### Example 4: Full Access for AI Tools or Automation
+
+Create a user with full read/write access across all databases, suitable for admin accounts or automation pipelines:
 
 ```sql
--- Create user with password change requirement
-CREATE USER new_employee IDENTIFIED BY 'temp123' WITH MUST_CHANGE_PASSWORD = true;
+-- Create a role with global access
+CREATE ROLE full_access_role;
+GRANT ALL ON *.* TO ROLE full_access_role;
 
--- Create user in disabled state
-CREATE USER temp_user IDENTIFIED BY 'abc123' WITH DISABLED = true;
+-- Create the user and assign the role
+CREATE USER admin_user IDENTIFIED BY 'SecurePass456!' WITH DEFAULT_ROLE = 'full_access_role';
+GRANT ROLE full_access_role TO admin_user;
+```
 
--- Create user with default role (role must be granted separately)
-CREATE USER manager IDENTIFIED BY 'abc123' WITH DEFAULT_ROLE = 'admin';
-GRANT ROLE admin TO manager;
+### Example 5: Read-Only Access Across All Databases
+
+Create a user that can only query data, suitable for dashboards, BI tools, or AI agents in safe mode:
+
+```sql
+-- Create a read-only role
+CREATE ROLE readonly_role;
+GRANT SELECT ON *.* TO ROLE readonly_role;
+
+-- Create the user
+CREATE USER readonly_user IDENTIFIED BY 'ReadOnly789!' WITH DEFAULT_ROLE = 'readonly_role';
+GRANT ROLE readonly_role TO readonly_user;
 ```

--- a/docs/en/sql-reference/10-sql-commands/10-dml/dml-copy-into-table.md
+++ b/docs/en/sql-reference/10-sql-commands/10-dml/dml-copy-into-table.md
@@ -706,3 +706,25 @@ SELECT * FROM t2;
 │ 6                │ null              │
 └──────────────────────────────────────┘
 ```
+
+### Example 8: Loading with Schema Evolution
+
+When loading Parquet files whose schemas contain columns not present in the target table, you can use schema evolution to automatically add the missing columns. First, enable schema evolution on the table:
+
+```sql
+CREATE OR REPLACE TABLE invoices(order_id INT);
+
+-- Enable schema evolution
+ALTER TABLE invoices SET OPTIONS(ENABLE_SCHEMA_EVOLUTION = true);
+```
+
+Then load Parquet files with different schemas. Databend automatically adds new columns and fills missing values with `NULL`:
+
+```sql
+-- Assume @my_stage contains Parquet files with extra columns (e.g., amount, currency)
+COPY INTO invoices
+    FROM @my_stage/
+    FILE_FORMAT = (TYPE = PARQUET MISSING_FIELD_AS = FIELD_DEFAULT);
+```
+
+For more details, see [Schema Evolution](/guides/load-data/transform/schema-evolution).


### PR DESCRIPTION
## Summary

Add documentation for the `ENABLE_SCHEMA_EVOLUTION` table option, which allows Databend to automatically add new columns during `COPY INTO` when source Parquet files contain columns not present in the target table.

## Changes

- **New guide**: `guides/load-data/transform/schema-evolution` (en/cn) with a fully runnable tutorial
- **Fuse Engine Options**: added `enable_schema_evolution` option description
- **ALTER TABLE**: added `enable_schema_evolution` to the UNSET OPTIONS list
- **COPY INTO reference**: added Example 8 demonstrating schema evolution

## Testing

All SQL examples verified against a local Databend instance.