### PR TITLE
Add llms.txt discovery for AI agents

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -51,6 +51,13 @@ const config: Config = {
         href: "/img/logo/logo-no-text.svg",
       },
     },
+    {
+      tagName: "link",
+      attributes: {
+        rel: "llms-txt",
+        href: "/llms.txt",
+      },
+    },
   ],
   customFields: {
     isChina: isCN,

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,7 @@
 User-agent: *
 Disallow: /404
 Disallow: /tags/
-Sitemap: https://www.databend.cn/sitemap.xml
+Sitemap: https://www.databend.com/sitemap.xml
+
+# LLM context
+Llms-Txt: /llms.txt


### PR DESCRIPTION
Enable AI agents to automatically discover the llms.txt file for full Databend documentation context.

Changes:
- Add `<link rel="llms-txt" href="/llms.txt">` in headTags
- Add `Llms-Txt: /llms.txt` declaration in robots.txt

Applies to both cn and en sites.