### PR TITLE
docs: add variant sub-field masking guide

### DIFF
--- a/docs/cn/guides/56-security/masking-policy.md
+++ b/docs/cn/guides/56-security/masking-policy.md
@@ -162,7 +162,20 @@ id | email              | is_vip
 
 在脱敏策略中使用 `object_delete` 可以隐藏 VARIANT 列中的指定 key。所有访问方式（下标访问、`json_path_query`、`get_path`、CAST、`json_object_keys`）都会生效——被隐藏的 key 返回 NULL 或从结果中消失。
 
-### 第一步：创建角色
+### 第一步：创建表并插入示例数据
+
+```sql
+CREATE TABLE events (
+  id INT,
+  data VARIANT
+);
+
+INSERT INTO events VALUES
+  (1, parse_json('{"name": "alice", "content": "secret data", "secret_key": "sk_123", "age": 30}')),
+  (2, parse_json('{"name": "bob", "content": "private info", "secret_key": "sk_456", "age": 25}'));
+```
+
+### 第二步：创建角色
 
 ```sql
 -- 可以看到完整 VARIANT 数据的角色
@@ -172,9 +185,10 @@ CREATE ROLE data_admin;
 CREATE ROLE data_reader;
 ```
 
-### 第二步：创建脱敏策略
+### 第三步：创建脱敏策略
 
 ```sql
+-- 对非管理员角色隐藏 'content' 和 'secret_key'
 CREATE MASKING POLICY mask_variant_sensitive
   AS (val VARIANT) RETURNS VARIANT ->
     CASE
@@ -183,33 +197,56 @@ CREATE MASKING POLICY mask_variant_sensitive
     END;
 ```
 
-### 第三步：绑定到 VARIANT 列
+### 第四步：绑定到 VARIANT 列
 
 ```sql
-ALTER TABLE my_table MODIFY COLUMN data SET MASKING POLICY mask_variant_sensitive;
+ALTER TABLE events MODIFY COLUMN data SET MASKING POLICY mask_variant_sensitive;
 ```
 
-### 第四步：授权
+### 第五步：授权
 
 ```sql
-GRANT SELECT ON my_db.my_table TO ROLE data_admin;
-GRANT SELECT ON my_db.my_table TO ROLE data_reader;
+GRANT SELECT ON default.events TO ROLE data_admin;
+GRANT SELECT ON default.events TO ROLE data_reader;
 GRANT ROLE data_admin TO USER 'admin_user';
 GRANT ROLE data_reader TO USER 'normal_user';
 ```
 
-### 第五步：验证
+### 第六步：验证
 
 ```sql
--- 以 data_reader 身份查询：
-SELECT data FROM my_table;
--- {"name":"alice","age":30}（content 已消失）
+-- 以 data_admin 身份查询：完整数据可见
+SET ROLE data_admin;
+SELECT data FROM events;
+-- {"age":30,"content":"secret data","name":"alice","secret_key":"sk_123"}
+-- {"age":25,"content":"private info","name":"bob","secret_key":"sk_456"}
 
-SELECT data['content'] FROM my_table;
+-- 以 data_reader 身份查询：敏感字段已删除
+SET ROLE data_reader;
+
+SELECT data FROM events;
+-- {"age":30,"name":"alice"}
+-- {"age":25,"name":"bob"}
+
+SELECT data['content'] FROM events;
+-- NULL
 -- NULL
 
-SELECT json_object_keys(data) FROM my_table;
--- ["age","name"]（content key 不可见）
+SELECT data['name'] FROM events;
+-- "alice"
+-- "bob"
+
+SELECT json_path_query_first(data, '$.content') FROM events;
+-- NULL
+
+SELECT data::STRING FROM events;
+-- {"age":30,"name":"alice"}
+
+SELECT json_object_keys(data) FROM events;
+-- ["age","name"]
+
+SELECT * FROM events WHERE data['content'] IS NOT NULL;
+-- （空结果）
 ```
 
 :::tip

--- a/docs/cn/guides/56-security/masking-policy.md
+++ b/docs/cn/guides/56-security/masking-policy.md
@@ -158,6 +158,67 @@ id | email              | is_vip
  2 | *********          | false
 ```
 
+## Variant 字段级脱敏
+
+在脱敏策略中使用 `object_delete` 可以隐藏 VARIANT 列中的指定 key。所有访问方式（下标访问、`json_path_query`、`get_path`、CAST、`json_object_keys`）都会生效——被隐藏的 key 返回 NULL 或从结果中消失。
+
+### 第一步：创建角色
+
+```sql
+-- 可以看到完整 VARIANT 数据的角色
+CREATE ROLE data_admin;
+
+-- 看不到敏感字段的角色
+CREATE ROLE data_reader;
+```
+
+### 第二步：创建脱敏策略
+
+```sql
+CREATE MASKING POLICY mask_variant_sensitive
+  AS (val VARIANT) RETURNS VARIANT ->
+    CASE
+      WHEN current_role() IN ('data_admin', 'account_admin') THEN val
+      ELSE object_delete(val, 'content', 'secret_key')
+    END;
+```
+
+### 第三步：绑定到 VARIANT 列
+
+```sql
+ALTER TABLE my_table MODIFY COLUMN data SET MASKING POLICY mask_variant_sensitive;
+```
+
+### 第四步：授权
+
+```sql
+GRANT SELECT ON my_db.my_table TO ROLE data_admin;
+GRANT SELECT ON my_db.my_table TO ROLE data_reader;
+GRANT ROLE data_admin TO USER 'admin_user';
+GRANT ROLE data_reader TO USER 'normal_user';
+```
+
+### 第五步：验证
+
+```sql
+-- 以 data_reader 身份查询：
+SELECT data FROM my_table;
+-- {"name":"alice","age":30}（content 已消失）
+
+SELECT data['content'] FROM my_table;
+-- NULL
+
+SELECT json_object_keys(data) FROM my_table;
+-- ["age","name"]（content key 不可见）
+```
+
+:::tip
+如需隐藏嵌套 key，使用 `delete_by_keypath`：
+```sql
+ELSE delete_by_keypath(val, 'nested:secret')
+```
+:::
+
 ## 权限与参考
 
 - 将 `CREATE MASKING POLICY`（通常授予 `*.*`）赋予负责创建或替换策略的角色，创建者会自动获得策略的 OWNERSHIP。

--- a/docs/cn/guides/56-security/masking-policy.md
+++ b/docs/cn/guides/56-security/masking-policy.md
@@ -188,14 +188,18 @@ CREATE ROLE data_reader;
 ### 第三步：创建脱敏策略
 
 ```sql
--- 对非管理员角色隐藏 'content' 和 'secret_key'
+-- 对没有 data_admin 角色的用户隐藏 'content' 和 'secret_key'
 CREATE MASKING POLICY mask_variant_sensitive
   AS (val VARIANT) RETURNS VARIANT ->
     CASE
-      WHEN current_role() IN ('data_admin', 'account_admin') THEN val
+      WHEN is_role_in_session('data_admin') OR is_role_in_session('account_admin') THEN val
       ELSE object_delete(val, 'content', 'secret_key')
     END;
 ```
+
+:::note
+`is_role_in_session`（v1.2.911 起可用）会检查用户被授予的所有角色，不依赖当前激活角色。相比 `current_role()`，用户无法通过 `SET ROLE` 切换角色来绕过脱敏。
+:::
 
 ### 第四步：绑定到 VARIANT 列
 

--- a/docs/cn/guides/56-security/masking-policy.md
+++ b/docs/cn/guides/56-security/masking-policy.md
@@ -160,7 +160,7 @@ id | email              | is_vip
 
 ## Variant 字段级脱敏
 
-在脱敏策略中使用 `object_delete` 可以隐藏 VARIANT 列中的指定 key。所有访问方式（下标访问、`json_path_query`、`get_path`、CAST、`json_object_keys`）都会生效——被隐藏的 key 返回 NULL 或从结果中消失。
+在脱敏策略中，`object_delete` 用于隐藏 VARIANT 列中的指定 key。该脱敏效果对所有访问方式（下标、`json_path_query`、`get_path`、CAST、`json_object_keys`）保持一致：被隐藏的 key 会表现为 NULL 或被完全剔除。
 
 ### 第一步：创建表并插入示例数据
 

--- a/docs/en/guides/56-security/masking-policy.md
+++ b/docs/en/guides/56-security/masking-policy.md
@@ -188,14 +188,18 @@ CREATE ROLE data_reader;
 ### Step 3: Create the masking policy
 
 ```sql
--- Hide 'content' and 'secret_key' from non-admin roles
+-- Hide 'content' and 'secret_key' from users without data_admin role
 CREATE MASKING POLICY mask_variant_sensitive
   AS (val VARIANT) RETURNS VARIANT ->
     CASE
-      WHEN current_role() IN ('data_admin', 'account_admin') THEN val
+      WHEN is_role_in_session('data_admin') OR is_role_in_session('account_admin') THEN val
       ELSE object_delete(val, 'content', 'secret_key')
     END;
 ```
+
+:::note
+`is_role_in_session` (available since v1.2.911) checks all roles granted to the user, regardless of which role is currently active. This is more secure than `current_role()` because users cannot bypass the mask by switching roles with `SET ROLE`.
+:::
 
 ### Step 4: Attach the policy to the VARIANT column
 

--- a/docs/en/guides/56-security/masking-policy.md
+++ b/docs/en/guides/56-security/masking-policy.md
@@ -158,6 +158,67 @@ id | email              | is_vip
  2 | *********          | false
 ```
 
+## Masking Variant Sub-Fields
+
+Use `object_delete` inside a masking policy to hide specific keys within a VARIANT column. All access paths (subscript, `json_path_query`, `get_path`, cast, `json_object_keys`) respect the mask—hidden keys return NULL or are absent from results.
+
+### Step 1: Create roles
+
+```sql
+-- Role that sees full VARIANT data
+CREATE ROLE data_admin;
+
+-- Role that cannot see sensitive keys
+CREATE ROLE data_reader;
+```
+
+### Step 2: Create the masking policy
+
+```sql
+CREATE MASKING POLICY mask_variant_sensitive
+  AS (val VARIANT) RETURNS VARIANT ->
+    CASE
+      WHEN current_role() IN ('data_admin', 'account_admin') THEN val
+      ELSE object_delete(val, 'content', 'secret_key')
+    END;
+```
+
+### Step 3: Attach the policy to a VARIANT column
+
+```sql
+ALTER TABLE my_table MODIFY COLUMN data SET MASKING POLICY mask_variant_sensitive;
+```
+
+### Step 4: Grant access
+
+```sql
+GRANT SELECT ON my_db.my_table TO ROLE data_admin;
+GRANT SELECT ON my_db.my_table TO ROLE data_reader;
+GRANT ROLE data_admin TO USER 'admin_user';
+GRANT ROLE data_reader TO USER 'normal_user';
+```
+
+### Step 5: Verify
+
+```sql
+-- As data_reader:
+SELECT data FROM my_table;
+-- {"name":"alice","age":30}  (content is gone)
+
+SELECT data['content'] FROM my_table;
+-- NULL
+
+SELECT json_object_keys(data) FROM my_table;
+-- ["age","name"]  (content key not visible)
+```
+
+:::tip
+For nested keys, use `delete_by_keypath`:
+```sql
+ELSE delete_by_keypath(val, 'nested:secret')
+```
+:::
+
 ## Privileges & References
 
 - Grant `CREATE MASKING POLICY` on `*.*` to any role responsible for creating or replacing policies; the creator automatically owns the policy.

--- a/docs/en/guides/56-security/masking-policy.md
+++ b/docs/en/guides/56-security/masking-policy.md
@@ -162,7 +162,20 @@ id | email              | is_vip
 
 Use `object_delete` inside a masking policy to hide specific keys within a VARIANT column. All access paths (subscript, `json_path_query`, `get_path`, cast, `json_object_keys`) respect the mask—hidden keys return NULL or are absent from results.
 
-### Step 1: Create roles
+### Step 1: Create a table with sample data
+
+```sql
+CREATE TABLE events (
+  id INT,
+  data VARIANT
+);
+
+INSERT INTO events VALUES
+  (1, parse_json('{"name": "alice", "content": "secret data", "secret_key": "sk_123", "age": 30}')),
+  (2, parse_json('{"name": "bob", "content": "private info", "secret_key": "sk_456", "age": 25}'));
+```
+
+### Step 2: Create roles
 
 ```sql
 -- Role that sees full VARIANT data
@@ -172,9 +185,10 @@ CREATE ROLE data_admin;
 CREATE ROLE data_reader;
 ```
 
-### Step 2: Create the masking policy
+### Step 3: Create the masking policy
 
 ```sql
+-- Hide 'content' and 'secret_key' from non-admin roles
 CREATE MASKING POLICY mask_variant_sensitive
   AS (val VARIANT) RETURNS VARIANT ->
     CASE
@@ -183,33 +197,56 @@ CREATE MASKING POLICY mask_variant_sensitive
     END;
 ```
 
-### Step 3: Attach the policy to a VARIANT column
+### Step 4: Attach the policy to the VARIANT column
 
 ```sql
-ALTER TABLE my_table MODIFY COLUMN data SET MASKING POLICY mask_variant_sensitive;
+ALTER TABLE events MODIFY COLUMN data SET MASKING POLICY mask_variant_sensitive;
 ```
 
-### Step 4: Grant access
+### Step 5: Grant access
 
 ```sql
-GRANT SELECT ON my_db.my_table TO ROLE data_admin;
-GRANT SELECT ON my_db.my_table TO ROLE data_reader;
+GRANT SELECT ON default.events TO ROLE data_admin;
+GRANT SELECT ON default.events TO ROLE data_reader;
 GRANT ROLE data_admin TO USER 'admin_user';
 GRANT ROLE data_reader TO USER 'normal_user';
 ```
 
-### Step 5: Verify
+### Step 6: Verify
 
 ```sql
--- As data_reader:
-SELECT data FROM my_table;
--- {"name":"alice","age":30}  (content is gone)
+-- As data_admin: full data visible
+SET ROLE data_admin;
+SELECT data FROM events;
+-- {"age":30,"content":"secret data","name":"alice","secret_key":"sk_123"}
+-- {"age":25,"content":"private info","name":"bob","secret_key":"sk_456"}
 
-SELECT data['content'] FROM my_table;
+-- As data_reader: sensitive keys removed
+SET ROLE data_reader;
+
+SELECT data FROM events;
+-- {"age":30,"name":"alice"}
+-- {"age":25,"name":"bob"}
+
+SELECT data['content'] FROM events;
+-- NULL
 -- NULL
 
-SELECT json_object_keys(data) FROM my_table;
--- ["age","name"]  (content key not visible)
+SELECT data['name'] FROM events;
+-- "alice"
+-- "bob"
+
+SELECT json_path_query_first(data, '$.content') FROM events;
+-- NULL
+
+SELECT data::STRING FROM events;
+-- {"age":30,"name":"alice"}
+
+SELECT json_object_keys(data) FROM events;
+-- ["age","name"]
+
+SELECT * FROM events WHERE data['content'] IS NOT NULL;
+-- (empty result)
 ```
 
 :::tip

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -51,6 +51,13 @@ const config: Config = {
         href: "/img/logo/logo-no-text.svg",
       },
     },
+    {
+      tagName: "link",
+      attributes: {
+        rel: "llms-txt",
+        href: "/llms.txt",
+      },
+    },
   ],
   customFields: {
     isChina: isCN,

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,7 @@
 User-agent: *
 Disallow: /404
 Disallow: /tags/
-Sitemap: https://www.databend.cn/sitemap.xml
+Sitemap: https://www.databend.com/sitemap.xml
+
+# LLM context
+Llms-Txt: /llms.txt


### PR DESCRIPTION
Add a new section to the masking policy guide (EN + CN) explaining how to mask specific keys within a VARIANT column using `object_delete` and `is_role_in_session`.

## Changes
- Added "Masking Variant Sub-Fields" section to EN masking-policy.md
- Added "Variant 字段级脱敏" section to CN masking-policy.md

## Highlights
- Uses `is_role_in_session` (v1.2.911+) instead of `current_role()` to prevent SET ROLE bypass
- Step-by-step guide: create table → create roles → create policy → bind column → grant → verify
- Covers all access patterns (subscript, json_path, cast, keys enumeration, WHERE filter)
- Verified on Databend Cloud (v1.2.911)