### PR TITLE
docs: clarify staged file pattern matching

### DIFF
--- a/docs/cn/guides/40-load-data/00-stage/00-what-is-stage.md
+++ b/docs/cn/guides/40-load-data/00-stage/00-what-is-stage.md
@@ -76,6 +76,22 @@ LIST @my_external_stage;
 LIST @~;
 ```
 
+## 使用 PATTERN 过滤 Stage 文件 {#filtering-staged-files-with-pattern}
+
+读取、列出、删除或检查 Stage 文件的命令和函数可以使用 `PATTERN` 按正则表达式过滤文件。对于 Stage 路径，`PATTERN` 匹配的是 `@<stage_name>[/<path>]` 之后的文件路径部分，而不是完整的 Stage URI。
+
+例如，对于 `@sales_stage/raw/`，Stage 文件 `@sales_stage/raw/year=2025/month=01/sales_20250101.parquet` 会作为 `year=2025/month=01/sales_20250101.parquet` 进行匹配：
+
+```sql
+LIST @sales_stage/raw/ PATTERN = 'year=2025/month=01/.*[.]parquet';
+```
+
+若要匹配 Stage 路径下的所有 `.log` 文件，可以使用如下正则表达式：
+
+```sql
+LIST @my_stage PATTERN = '.*[.]log';
+```
+
 ## 管理 Stage
 
 Databend 提供以下命令来管理 Stage 及其中的文件：

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/03-stage/04-ddl-list-stage.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/03-stage/04-ddl-list-stage.md
@@ -17,6 +17,8 @@ sidebar_position: 4
 LIST { userStage | internalStage | externalStage } [ PATTERN = '<regex_pattern>' ]
 ```
 
+`PATTERN` 按正则表达式过滤 Stage 文件。它匹配的是 `@<stage_name>[/<path>]` 之后的文件路径部分。参见 [使用 PATTERN 过滤 Stage 文件](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern)。
+
 ## 示例
 
 下面的 Stage 包含一个名为 **books.parquet** 的文件和一个名为 **2023** 的文件夹。
@@ -58,10 +60,10 @@ LIST @my_internal_stage/2023/;
 +-----------------+------+------------------------------------+-------------------------------+---------+
 ```
 
-要列出 Stage 中所有扩展名为 *.log 的文件，请运行以下命令：
+要列出 Stage 中所有扩展名为 `.log` 的文件，请运行以下命令：
 
 ```sql
-LIST @my_internal_stage PATTERN = '.log';
+LIST @my_internal_stage PATTERN = '.*[.]log';
 +----------------+------+------------------------------------+-------------------------------+---------+
 |      name      | size |                md5                 |         last_modified         | creator |
 +----------------+------+------------------------------------+-------------------------------+---------+

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/03-stage/05-ddl-remove-stage.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/03-stage/05-ddl-remove-stage.md
@@ -31,7 +31,7 @@ externalStage ::= @<external_stage_name>[/<file>]
 
 ### PATTERN = 'regex_pattern'
 
-一个正则表达式模式字符串，用单引号括起来，用于按文件名过滤要删除的文件。
+一个正则表达式模式字符串，用单引号括起来，用于过滤要删除的 Stage 文件。它匹配的是 `@<stage_name>[/<path>]` 之后的文件路径部分。参见 [使用 PATTERN 过滤 Stage 文件](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern)。
 
 ## 示例
 

--- a/docs/cn/sql-reference/10-sql-commands/10-dml/dml-copy-into-table.md
+++ b/docs/cn/sql-reference/10-sql-commands/10-dml/dml-copy-into-table.md
@@ -186,7 +186,7 @@ copyOptions ::=
 
 - **FILES**：指定一个或多个待加载文件名（以逗号分隔）。
 
-- **PATTERN**：基于 [PCRE2](https://www.pcre.org/current/doc/html/) 的正则表达式模式字符串，用于匹配文件名。参见 [示例 4：使用模式过滤文件](#example-4-filtering-files-with-pattern)。
+- **PATTERN**：基于 [PCRE2](https://www.pcre.org/current/doc/html/) 的正则表达式模式字符串，用于匹配文件名。从 Stage 加载时，该模式匹配的是 `@<stage_name>[/<path>]` 之后的文件路径部分。参见 [使用 PATTERN 过滤 Stage 文件](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern) 和 [示例 4：使用模式过滤文件](#example-4-filtering-files-with-pattern)。
 
 ## 格式类型选项
 
@@ -534,20 +534,20 @@ COPY INTO mytable
     );
 ```
 
-为包含多级目录的文件路径指定模式时，请根据匹配需求选择：
+为包含多级目录的 Stage 文件路径指定模式时，请注意模式只匹配 `@<stage_name>[/<path>]` 之后的路径部分。例如，对于 `FROM @sales_stage/raw/`，文件 `@sales_stage/raw/year=2025/month=01/sales_20250101.parquet` 会作为 `year=2025/month=01/sales_20250101.parquet` 进行匹配。
 
-- 若要匹配前缀后的特定子路径，请在模式中包含该前缀（如 'multi_page/'），再指定子路径内的匹配模式（如 '\_page_1'）。
+- 若要匹配前缀后的特定子路径，请在模式中包含该前缀（如 'year=2025/month=01/'），再指定子路径内的匹配模式（如 'sales_'）。
 
 ```sql
--- 文件路径：parquet/multi_page/multi_page_1.parquet
-COPY INTO ... FROM @data/parquet/ PATTERN = 'multi_page/.*_page_1.*') ...
+-- 文件路径：raw/year=2025/month=01/sales_20250101.parquet
+COPY INTO ... FROM @sales_stage/raw/ PATTERN = 'year=2025/month=01/.*sales_.*[.]parquet') ...
 ```
 
-- 若要匹配文件路径中任意位置出现的目标模式，请在模式前后加 '.*'（如 '.*multi_page_1.\*'）以匹配路径中任意位置的 'multi_page_1'。
+- 若要匹配文件路径中任意位置出现的目标模式，请在模式前后加 '.*'（如 '.*sales_20250101.*'）以匹配路径中任意位置的 'sales_20250101'。
 
 ```sql
--- 文件路径：parquet/multi_page/multi_page_1.parquet
-COPY INTO ... FROM @data/parquet/ PATTERN ='.*multi_page_1.*') ...
+-- 文件路径：raw/year=2025/month=01/sales_20250101.parquet
+COPY INTO ... FROM @sales_stage/raw/ PATTERN = '.*sales_20250101.*') ...
 ```
 
 ### 示例 5：加载到含额外列的表

--- a/docs/cn/sql-reference/20-sql-functions/17-table-functions/01-infer-schema.md
+++ b/docs/cn/sql-reference/20-sql-functions/17-table-functions/01-infer-schema.md
@@ -43,7 +43,7 @@ INFER_SCHEMA(
 | 参数 | 描述 | 默认值 | 示例 |
 |-----------|-------------|---------|---------|
 | `LOCATION` | 暂存区位置：`@<stage_name>[/<path>]` | 必需 | `'@my_stage/data/'` |
-| `PATTERN` | 文件名匹配模式 | 所有文件 | `'*.csv'`, `'*.parquet'` |
+| `PATTERN` | 用于匹配 Stage 文件的正则表达式模式。它匹配的是 `@<stage_name>[/<path>]` 之后的文件路径部分。参见 [使用 PATTERN 过滤 Stage 文件](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern)。 | 所有文件 | `'.*[.]csv'`, `'.*[.]parquet'` |
 | `FILE_FORMAT` | 解析用的文件格式名称 | 暂存区格式 | `'csv_format'`, `'NDJSON'` |
 | `MAX_RECORDS_PRE_FILE` | 每文件采样的最大记录数 | 所有记录 | `100`, `1000` |
 | `MAX_FILE_COUNT` | 处理的最大文件数 | 所有文件 | `5`, `10` |
@@ -60,7 +60,7 @@ COPY INTO @test_parquet FROM (SELECT number FROM numbers(10)) FILE_FORMAT = (TYP
 -- 使用模式从 Parquet 文件推断模式
 SELECT * FROM INFER_SCHEMA(
     location => '@test_parquet',
-    pattern => '*.parquet'
+    pattern => '.*[.]parquet'
 );
 ```
 
@@ -86,7 +86,7 @@ CREATE FILE FORMAT csv_format TYPE = 'CSV';
 -- 使用模式和文件格式推断模式
 SELECT * FROM INFER_SCHEMA(
     location => '@test_csv',
-    pattern => '*.csv',
+    pattern => '.*[.]csv',
     file_format => 'csv_format'
 );
 ```
@@ -129,7 +129,7 @@ SELECT * FROM INFER_SCHEMA(
 -- 仅采样前 5 条记录进行模式推断
 SELECT * FROM INFER_SCHEMA(
     location => '@test_csv',
-    pattern => '*.csv',
+    pattern => '.*[.]csv',
     file_format => 'csv_format',
     max_records_pre_file => 5
 );
@@ -145,7 +145,7 @@ COPY INTO @test_ndjson FROM (SELECT number FROM numbers(10)) FILE_FORMAT = (TYPE
 -- 使用模式和 NDJSON 格式推断模式
 SELECT * FROM INFER_SCHEMA(
     location => '@test_ndjson',
-    pattern => '*.ndjson',
+    pattern => '.*[.]ndjson',
     file_format => 'NDJSON'
 );
 ```
@@ -165,7 +165,7 @@ SELECT * FROM INFER_SCHEMA(
 -- 仅采样前 5 条记录进行模式推断
 SELECT * FROM INFER_SCHEMA(
     location => '@test_ndjson',
-    pattern => '*.ndjson',
+    pattern => '.*[.]ndjson',
     file_format => 'NDJSON',
     max_records_pre_file => 5
 );
@@ -183,7 +183,7 @@ SELECT * FROM INFER_SCHEMA(
 
 SELECT * FROM INFER_SCHEMA(
     location => '@my_stage/',
-    pattern => '*.csv',
+    pattern => '.*[.]csv',
     file_format => 'csv_format'
 );
 ```
@@ -207,7 +207,7 @@ SELECT * FROM INFER_SCHEMA(
 -- 从目录中所有 CSV 文件推断模式
 SELECT * FROM INFER_SCHEMA(
     location => '@my_stage/',
-    pattern => '*.csv'
+    pattern => '.*[.]csv'
 );
 ```
 
@@ -217,7 +217,7 @@ SELECT * FROM INFER_SCHEMA(
 -- 仅处理前 5 个匹配文件
 SELECT * FROM INFER_SCHEMA(
     location => '@my_stage/',
-    pattern => '*.csv',
+    pattern => '.*[.]csv',
     max_file_count => 5
 );
 ```
@@ -245,7 +245,7 @@ SELECT * FROM INFER_SCHEMA(
 ```sql
 -- 从文件模式创建表结构
 CREATE TABLE my_table AS
-SELECT * FROM @my_stage/ (pattern=>'*.parquet')
+SELECT * FROM @my_stage/ (pattern=>'.*[.]parquet')
 LIMIT 0;
 
 -- 验证表结构

--- a/docs/cn/sql-reference/20-sql-functions/17-table-functions/03-list-stage.md
+++ b/docs/cn/sql-reference/20-sql-functions/17-table-functions/03-list-stage.md
@@ -38,7 +38,7 @@ userStage ::= @~[/<path>]
 
 ### PATTERN
 
-参见 [COPY INTO table](/10-sql-commands/10-dml/dml-copy-into-table.md)。
+按正则表达式过滤 Stage 文件。它匹配的是 `@<stage_name>[/<path>]` 之后的文件路径部分。参见 [使用 PATTERN 过滤 Stage 文件](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern)。
 
 
 ## 示例
@@ -53,5 +53,5 @@ SELECT * FROM list_stage(location => '@my_stage/', pattern => '.*[.]log');
 +----------------+------+------------------------------------+-------------------------------+---------+
 
 -- 等同于以下语句：
-LIST @my_stage PATTERN = '.log';
+LIST @my_stage PATTERN = '.*[.]log';
 ```

--- a/docs/en/guides/40-load-data/00-stage/00-what-is-stage.md
+++ b/docs/en/guides/40-load-data/00-stage/00-what-is-stage.md
@@ -73,6 +73,22 @@ The user stage can serve as a convenient repository for your data files that do 
 LIST @~;
 ```
 
+## Filtering Staged Files with PATTERN
+
+Commands and functions that read, list, remove, or inspect staged files can use `PATTERN` to filter files by regular expression. For staged locations, `PATTERN` matches the file path portion after `@<stage_name>[/<path>]`, not the full stage URI.
+
+For example, with `@sales_stage/raw/`, the staged file `@sales_stage/raw/year=2025/month=01/sales_20250101.parquet` is matched as `year=2025/month=01/sales_20250101.parquet`:
+
+```sql
+LIST @sales_stage/raw/ PATTERN = 'year=2025/month=01/.*[.]parquet';
+```
+
+To match all `.log` files under a stage path, use a regular expression such as:
+
+```sql
+LIST @my_stage PATTERN = '.*[.]log';
+```
+
 ## Managing Stages
 
 Databend provides a variety of commands to assist you in managing stages and the files staged within them:

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/03-stage/04-ddl-list-stage.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/03-stage/04-ddl-list-stage.md
@@ -17,6 +17,8 @@ See also:
 LIST { userStage | internalStage | externalStage } [ PATTERN = '<regex_pattern>' ]
 ```
 
+`PATTERN` filters staged files by regular expression. It matches the file path portion after `@<stage_name>[/<path>]`. See [Filtering Staged Files with PATTERN](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern).
+
 ## Examples
 
 The stage below contains a file named **books.parquet** and a folder named **2023**.
@@ -58,10 +60,10 @@ LIST @my_internal_stage/2023/;
 +-----------------+------+------------------------------------+-------------------------------+---------+
 ```
 
-To list all the files with the extension *.log in the stage, run the following command:
+To list all the files with the extension `.log` in the stage, run the following command:
 
 ```sql
-LIST @my_internal_stage PATTERN = '.log';
+LIST @my_internal_stage PATTERN = '.*[.]log';
 +----------------+------+------------------------------------+-------------------------------+---------+
 |      name      | size |                md5                 |         last_modified         | creator |
 +----------------+------+------------------------------------+-------------------------------+---------+

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/03-stage/05-ddl-remove-stage.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/03-stage/05-ddl-remove-stage.md
@@ -31,7 +31,7 @@ externalStage ::= @<external_stage_name>[/<file>]
 
 ### PATTERN = 'regex_pattern'
 
-A regular expression pattern string, enclosed in single quotes, filters files to remove by their filename.
+A regular expression pattern string, enclosed in single quotes, filters staged files to remove. It matches the file path portion after `@<stage_name>[/<path>]`. See [Filtering Staged Files with PATTERN](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern).
 
 ## Examples
 

--- a/docs/en/sql-reference/10-sql-commands/10-dml/dml-copy-into-table.md
+++ b/docs/en/sql-reference/10-sql-commands/10-dml/dml-copy-into-table.md
@@ -186,7 +186,7 @@ For remote files, you can use glob patterns to specify multiple files. For examp
 
 - **FILES**: Specifies one or more file names (separated by commas) to be loaded.
 
-- **PATTERN**: A [PCRE2](https://www.pcre.org/current/doc/html/)-based regular expression pattern string that specifies file names to match. See [Example 4: Filtering Files with Pattern](#example-4-filtering-files-with-pattern).
+- **PATTERN**: A [PCRE2](https://www.pcre.org/current/doc/html/)-based regular expression pattern string that specifies file names to match. When loading from a stage, the pattern matches the part of the file path after `@<stage_name>[/<path>]`. See [Filtering Staged Files with PATTERN](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern) and [Example 4: Filtering Files with Pattern](#example-4-filtering-files-with-pattern).
 
 ## Format Type Options
 
@@ -534,20 +534,20 @@ COPY INTO mytable
     );
 ```
 
-When specifying the pattern for a file path including multiple folders, consider your matching criteria:
+When specifying the pattern for staged files in paths with multiple folders, remember that the pattern matches only the path portion after `@<stage_name>[/<path>]`. For example, with `FROM @sales_stage/raw/`, the file `@sales_stage/raw/year=2025/month=01/sales_20250101.parquet` is matched as `year=2025/month=01/sales_20250101.parquet`.
 
-- If you want to match a specific subpath following a prefix, include the prefix in the pattern (e.g., 'multi_page/') and then specify the pattern you want to match within that subpath (e.g., '\_page_1').
+- If you want to match a specific subpath following a prefix, include the prefix in the pattern (e.g., 'year=2025/month=01/') and then specify the pattern you want to match within that subpath (e.g., 'sales_').
 
 ```sql
--- File path: parquet/multi_page/multi_page_1.parquet
-COPY INTO ... FROM @data/parquet/ PATTERN = 'multi_page/.*_page_1.*') ...
+-- File path: raw/year=2025/month=01/sales_20250101.parquet
+COPY INTO ... FROM @sales_stage/raw/ PATTERN = 'year=2025/month=01/.*sales_.*[.]parquet') ...
 ```
 
-- If you want to match any part of the file path that contains the desired pattern, use '.*' before and after the pattern (e.g., '.*multi_page_1.\*') to match any occurrences of 'multi_page_1' within the path.
+- If you want to match any part of the file path that contains the desired pattern, use '.*' before and after the pattern (e.g., '.*sales_20250101.*') to match any occurrences of 'sales_20250101' within the path.
 
 ```sql
--- File path: parquet/multi_page/multi_page_1.parquet
-COPY INTO ... FROM @data/parquet/ PATTERN ='.*multi_page_1.*') ...
+-- File path: raw/year=2025/month=01/sales_20250101.parquet
+COPY INTO ... FROM @sales_stage/raw/ PATTERN = '.*sales_20250101.*') ...
 ```
 
 ### Example 5: Loading to Table with Extra Columns

--- a/docs/en/sql-reference/20-sql-functions/17-table-functions/01-infer-schema.md
+++ b/docs/en/sql-reference/20-sql-functions/17-table-functions/01-infer-schema.md
@@ -43,7 +43,7 @@ INFER_SCHEMA(
 | Parameter | Description | Default | Example |
 |-----------|-------------|---------|---------|
 | `LOCATION` | Stage location: `@<stage_name>[/<path>]` | Required | `'@my_stage/data/'` |
-| `PATTERN` | File name pattern to match | All files | `'*.csv'`, `'*.parquet'` |
+| `PATTERN` | Regular expression pattern to match staged files. It matches the file path portion after `@<stage_name>[/<path>]`. See [Filtering Staged Files with PATTERN](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern). | All files | `'.*[.]csv'`, `'.*[.]parquet'` |
 | `FILE_FORMAT` | File format name for parsing | Stage's format | `'csv_format'`, `'NDJSON'` |
 | `MAX_RECORDS_PRE_FILE` | Max records to sample per file | All records | `100`, `1000` |
 | `MAX_FILE_COUNT` | Max number of files to process | All files | `5`, `10` |
@@ -60,7 +60,7 @@ COPY INTO @test_parquet FROM (SELECT number FROM numbers(10)) FILE_FORMAT = (TYP
 -- Infer schema from parquet files using pattern
 SELECT * FROM INFER_SCHEMA(
     location => '@test_parquet',
-    pattern => '*.parquet'
+    pattern => '.*[.]parquet'
 );
 ```
 
@@ -86,7 +86,7 @@ CREATE FILE FORMAT csv_format TYPE = 'CSV';
 -- Infer schema using pattern and file format
 SELECT * FROM INFER_SCHEMA(
     location => '@test_csv',
-    pattern => '*.csv',
+    pattern => '.*[.]csv',
     file_format => 'csv_format'
 );
 ```
@@ -129,7 +129,7 @@ Limit records for faster inference:
 -- Sample only first 5 records for schema inference
 SELECT * FROM INFER_SCHEMA(
     location => '@test_csv',
-    pattern => '*.csv',
+    pattern => '.*[.]csv',
     file_format => 'csv_format',
     max_records_pre_file => 5
 );
@@ -145,7 +145,7 @@ COPY INTO @test_ndjson FROM (SELECT number FROM numbers(10)) FILE_FORMAT = (TYPE
 -- Infer schema using pattern and NDJSON format
 SELECT * FROM INFER_SCHEMA(
     location => '@test_ndjson',
-    pattern => '*.ndjson',
+    pattern => '.*[.]ndjson',
     file_format => 'NDJSON'
 );
 ```
@@ -165,7 +165,7 @@ Limit records for faster inference:
 -- Sample only first 5 records for schema inference
 SELECT * FROM INFER_SCHEMA(
     location => '@test_ndjson',
-    pattern => '*.ndjson',
+    pattern => '.*[.]ndjson',
     file_format => 'NDJSON',
     max_records_pre_file => 5
 );
@@ -183,7 +183,7 @@ When files have different schemas, `infer_schema` merges them intelligently:
 
 SELECT * FROM INFER_SCHEMA(
     location => '@my_stage/',
-    pattern => '*.csv',
+    pattern => '.*[.]csv',
     file_format => 'csv_format'
 );
 ```
@@ -207,7 +207,7 @@ Use pattern matching to infer schema from multiple files:
 -- Infer schema from all CSV files in the directory
 SELECT * FROM INFER_SCHEMA(
     location => '@my_stage/',
-    pattern => '*.csv'
+    pattern => '.*[.]csv'
 );
 ```
 
@@ -217,7 +217,7 @@ Limit the number of files processed to improve performance:
 -- Process only the first 5 matching files
 SELECT * FROM INFER_SCHEMA(
     location => '@my_stage/',
-    pattern => '*.csv',
+    pattern => '.*[.]csv',
     max_file_count => 5
 );
 ```
@@ -245,7 +245,7 @@ The `infer_schema` function displays the schema but doesn't create tables. To cr
 ```sql
 -- Create table structure from file schema
 CREATE TABLE my_table AS
-SELECT * FROM @my_stage/ (pattern=>'*.parquet')
+SELECT * FROM @my_stage/ (pattern=>'.*[.]parquet')
 LIMIT 0;
 
 -- Verify the table structure

--- a/docs/en/sql-reference/20-sql-functions/17-table-functions/03-list-stage.md
+++ b/docs/en/sql-reference/20-sql-functions/17-table-functions/03-list-stage.md
@@ -38,7 +38,7 @@ userStage ::= @~[/<path>]
 
 ### PATTERN
 
-See [COPY INTO table](/10-sql-commands/10-dml/dml-copy-into-table.md).
+Filters staged files by regular expression. It matches the file path portion after `@<stage_name>[/<path>]`. See [Filtering Staged Files with PATTERN](/guides/load-data/stage/what-is-stage#filtering-staged-files-with-pattern).
 
 
 ## Examples
@@ -53,5 +53,5 @@ SELECT * FROM list_stage(location => '@my_stage/', pattern => '.*[.]log');
 +----------------+------+------------------------------------+-------------------------------+---------+
 
 -- Equivalent to the following statement:
-LIST @my_stage PATTERN = '.log';
+LIST @my_stage PATTERN = '.*[.]log';
 ```


### PR DESCRIPTION
## Motivation

The `PATTERN` option is used by multiple stage-related commands and functions, but the docs did not consistently explain what path string the regex is matched against. This could make users include the stage name or stage prefix incorrectly, and some examples used glob-style patterns where regex examples are expected.

## Summary

- Add shared explanations for filtering staged files with `PATTERN` in both English and Chinese Stage guides.
- Clarify that staged file patterns match the path portion after `@<stage_name>[/<path>]`.
- Update `LIST`, `REMOVE`, `COPY INTO`, `LIST_STAGE`, and `INFER_SCHEMA` docs in both languages to link to the shared explanation.
- Fix stage pattern examples to use regex-style patterns such as `.*[.]log` and `.*[.]csv`.

## Testing

- Ran static grep checks for stale examples like `PATTERN = '.log'`, `multi_page`, `@data/parquet`, and glob-style `INFER_SCHEMA` patterns.
- Attempted `site=en site_env=production npx docusaurus build`, but it failed before building docs because local `node_modules` has Docusaurus 3.9.2 while the config uses Docusaurus 3.10 fields (`future.faster`, `future.experimental_vcs`, `storage`).
