### PR TITLE
docs: add private task config

### DIFF
--- a/docs/cn/guides/20-self-hosted/04-references/node-config/query-config.md
+++ b/docs/cn/guides/20-self-hosted/04-references/node-config/query-config.md
@@ -58,6 +58,25 @@ import DetailsWrap from '@site/src/components/DetailsWrap';
 | aggregate_spilling_memory_ratio | 聚合操作触发磁盘溢出的内存阈值百分比。当内存使用超过总可用内存的该百分比时，数据将溢出到对象存储以避免内存耗尽。例如设为 60，则内存使用超过 60% 时触发溢出。 |
 | join_spilling_memory_ratio | Join 操作触发磁盘溢出的内存阈值百分比。当内存使用超过总可用内存的该百分比时，数据将溢出到对象存储以避免内存耗尽。例如设为 60，则内存使用超过 60% 时触发溢出。 |
 
+## [task] 部分
+
+在私有化部署中，可使用 [task] 部分启用私有化 Task：
+
+```toml
+[task]
+on = true
+```
+
+私有化 Task 需要带有 `private_task` 功能的企业版 License。
+
+:::note
+启用私有化 Task 时，[query] 部分中的 `cloud_control_grpc_server_address` 必须为空，否则 Databend Query 将无法启动。
+:::
+
+| 参数 | 描述 |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| on | 是否在 Databend Query 节点上启用私有化 Task 调度与执行，默认为 `false`。 |
+
 ## [log] 部分
 
 该部分可包含以下子部分：[log.file]、[log.stderr]、[log.query] 和 [log.tracing]。

--- a/docs/en/guides/20-self-hosted/04-references/node-config/query-config.md
+++ b/docs/en/guides/20-self-hosted/04-references/node-config/query-config.md
@@ -58,6 +58,25 @@ The following is a list of the parameters available within the [query.settings] 
 | aggregate_spilling_memory_ratio | Controls the threshold for spilling data to disk during aggregation operations. When memory usage exceeds this percentage of the total available memory, data will be spilled to the object storage to avoid memory exhaustion. Example: if set to 60, spilling occurs when memory usage exceeds 60%. |
 | join_spilling_memory_ratio      | Controls the threshold for spilling data to disk during join operations. When memory usage exceeds this percentage of the total available memory, data will be spilled to the object storage to avoid memory exhaustion. Example: if set to 60, spilling occurs when memory usage exceeds 60%.        |
 
+## [task] Section
+
+Use the [task] section to enable private task support for self-hosted deployments:
+
+```toml
+[task]
+on = true
+```
+
+Private task support requires an Enterprise Edition license with the `private_task` feature.
+
+:::note
+When private task is enabled, `cloud_control_grpc_server_address` in the [query] section must be empty. Otherwise, Databend Query cannot start.
+:::
+
+| Parameter | Description                                                                                                      |
+| --------- | ---------------------------------------------------------------------------------------------------------------- |
+| on        | Enables private task scheduling and execution on Databend Query nodes. Defaults to `false`.                      |
+
 ## [log] Section
 
 This section can include these subsections: [log.file], [log.stderr], [log.query], and [log.tracing].


### PR DESCRIPTION
## Summary

- Add the `[task]` section to the English and Chinese Query configuration references.
- Document `on = true`, the `private_task` license requirement, and the `cloud_control_grpc_server_address` constraint.

## Test

- `git diff --check`
- Not run: `npm run build:en` (`node_modules` is missing; `generate-release-index.js` cannot resolve `axios`)
