### PR TITLE
docs: clarify identifier case-sensitivity settings and defaults

### DIFF
--- a/docs/cn/sql-reference/00-sql-reference/40-sql-identifiers.md
+++ b/docs/cn/sql-reference/00-sql-reference/40-sql-identifiers.md
@@ -43,12 +43,39 @@ _my_databend
 默认情况下，Databend 以小写形式存储未引用的标识符，并按输入的方式存储双引号标识符。换句话说，Databend 将对象名称（如数据库、表和列）视为不区分大小写。 如果希望 Databend 将它们视为区分大小写，请使用双引号将其引起来。
 
 :::note
-Databend 允许您控制标识符的大小写敏感性。 有两个关键设置可用：
+默认情况下，Databend 采用 PostgreSQL 风格的标识符大小写规则：未加引号的标识符会被折叠为小写，而双引号标识符则保留原始大小写并区分大小写。这一行为由两个设置控制：
 
-- unquoted_ident_case_sensitive：设置为 1 时，此选项保留未引用标识符的字符大小写，确保它们区分大小写。 如果保留默认值 0，则未引用的标识符仍不区分大小写，并转换为小写。
+- `unquoted_ident_case_sensitive`：默认值为 `0`，即未引用标识符不区分大小写，并被折叠为小写。将其设置为 `1` 时，保留未引用标识符的大小写，使其区分大小写。
 
-- quoted_ident_case_sensitive：通过将此选项设置为 0，您可以指示双引号标识符不应保留字符的大小写，从而使其不区分大小写。
+- `quoted_ident_case_sensitive`：默认值为 `1`，即双引号标识符保留字符大小写、区分大小写。将其设置为 `0` 时，双引号标识符不区分大小写。
+
+如果您希望使用 MySQL 风格、无论是否加引号都不区分大小写的行为，可以将 `unquoted_ident_case_sensitive` 和 `quoted_ident_case_sensitive` 都设置为 `0`。
 :::
+
+### 为什么 `SELECT *` 能成功，而 `SELECT <列名>` 却失败
+
+一个常见的困惑来自这样的表：它的列是用保留大小写的引号（双引号或反引号）创建的，例如 `"Employee_ID"`。在默认设置下，`SELECT *` 能正常返回数据，但按列名引用时，无论大小写怎么写都会失败：
+
+```sql
+-- 创建时保留了列名大小写
+CREATE TABLE xxxTable ("Employee_ID" INT, "Department" VARCHAR);
+INSERT INTO xxxTable VALUES (1, 'Eng');
+
+-- 成功：没有按名称引用任何列
+SELECT * FROM xxxTable;
+
+-- 失败：未引用的列名被折叠为小写（employee_id / department），
+-- 与存储的 "Employee_ID" / "Department" 不匹配
+SELECT Employee_ID FROM xxxTable;
+SELECT employee_id FROM xxxTable;
+
+-- 成功：双引号保留了大小写，与存储的列名匹配
+SELECT "Employee_ID" FROM xxxTable;
+```
+
+这是因为 `unquoted_ident_case_sensitive` 默认值为 `0`，所以 `Employee_ID` 和 `employee_id` 都会被解析为 `employee_id`，而该列并不存在。要确认列名的实际大小写，可以运行 `DESC xxxTable;` 或 `SHOW CREATE TABLE xxxTable;`。
+
+为避免此问题，您可以用双引号并按创建时的确切大小写引用列名；更推荐的做法是，在创建数据库、表和列时只使用小写字母、数字和下划线（不加引号）。
 
 此示例演示了 Databend 在创建和列出数据库时如何处理标识符的大小写：
 

--- a/docs/en/sql-reference/00-sql-reference/40-sql-identifiers.md
+++ b/docs/en/sql-reference/00-sql-reference/40-sql-identifiers.md
@@ -43,12 +43,39 @@ Note that using double backticks (``) or double quotes (") is equivalent:
 Databend stores unquoted identifiers by default in lowercase and double-quoted identifiers as they are entered. In other words, Databend handles object names, such as databases, tables, and columns, as case-insensitive. If you want Databend to handle them as case-sensitive, double-quote them.
 
 :::note
-Databend allows you to have control over the casing sensitivity of identifiers. Two key settings are available:
+By default, Databend follows PostgreSQL-style identifier casing: unquoted identifiers are folded to lowercase, while double-quoted identifiers preserve their exact case and are case-sensitive. This behavior is controlled by two settings:
 
-- unquoted_ident_case_sensitive: When set to 1, this option preserves the case of characters for unquoted identifiers, ensuring they are case-sensitive. If left at the default value of 0, unquoted identifiers remain case-insensitive, converting to lowercase.
+- `unquoted_ident_case_sensitive`: Defaults to `0`, so unquoted identifiers are case-insensitive and folded to lowercase. Setting it to `1` preserves the case of unquoted identifiers, making them case-sensitive.
 
-- quoted_ident_case_sensitive: By setting this option to 0, you can indicate that double-quoted identifiers should not preserve the case of characters, making them case-insensitive.
+- `quoted_ident_case_sensitive`: Defaults to `1`, so double-quoted identifiers preserve the case of characters and are case-sensitive. Setting it to `0` makes double-quoted identifiers case-insensitive.
+
+If you prefer MySQL-style behavior where identifiers are case-insensitive regardless of quoting, set both `unquoted_ident_case_sensitive` and `quoted_ident_case_sensitive` to `0`.
 :::
+
+### Why `SELECT *` works but `SELECT <column>` fails
+
+A common source of confusion is a table whose columns were created with case-preserving quotes (double quotes or backticks), for example `"Employee_ID"`. With the default settings, `SELECT *` returns data, but referencing a column by name fails no matter how you case it:
+
+```sql
+-- Columns created with the case preserved
+CREATE TABLE xxxTable ("Employee_ID" INT, "Department" VARCHAR);
+INSERT INTO xxxTable VALUES (1, 'Eng');
+
+-- Works: no column is referenced by name
+SELECT * FROM xxxTable;
+
+-- Fails: unquoted names are folded to lowercase (employee_id / department),
+-- which do not match the stored "Employee_ID" / "Department"
+SELECT Employee_ID FROM xxxTable;
+SELECT employee_id FROM xxxTable;
+
+-- Works: double quotes preserve the case and match the stored column name
+SELECT "Employee_ID" FROM xxxTable;
+```
+
+This happens because `unquoted_ident_case_sensitive` defaults to `0`, so both `Employee_ID` and `employee_id` are resolved as `employee_id`, which does not exist. To confirm the actual column casing, run `DESC xxxTable;` or `SHOW CREATE TABLE xxxTable;`.
+
+To avoid this, either reference the column with double quotes using the exact case from creation time, or, better, use only lowercase letters, digits, and underscores (no quoting) when creating databases, tables, and columns.
 
 This example demonstrates how Databend treats the casing of identifiers when creating and listing databases:
 


### PR DESCRIPTION
## Summary

Addresses #3444. Rather than adding a separate "Common Pitfalls" chapter, this clarifies the two case-sensitivity settings directly in the existing "Identifier Casing Rules" section, since the reported symptom (`SELECT *` works but `SELECT <column>` fails) is entirely explained by how these settings behave.

Changes to `sql-identifiers.md` (both EN and CN):

- State that Databend follows PostgreSQL-style casing by default: unquoted identifiers fold to lowercase, double-quoted identifiers preserve case and are case-sensitive.
- Document the defaults explicitly: `unquoted_ident_case_sensitive=0`, `quoted_ident_case_sensitive=1`.
- Note the MySQL-style all-insensitive option: set both settings to `0`.
- Add a short troubleshooting subsection explaining why `SELECT *` works but `SELECT <column>` fails when columns were created with case-preserving quotes, with a runnable example and a pointer to `DESC` / `SHOW CREATE TABLE`.

## Tested

Documentation-only change. Reviewed rendered Markdown structure.

Closes #3444