### PR TITLE
docs: add AI document pipeline tutorial

### DIFF
--- a/docs/cn/guides/51-ai-functions/01-external-functions.md
+++ b/docs/cn/guides/51-ai-functions/01-external-functions.md
@@ -34,19 +34,16 @@ model = SentenceTransformer('all-mpnet-base-v2')  # 768 维向量
 
 @udf(
     input_types=["STRING"],
-    result_type="ARRAY(FLOAT)",
+    result_type="VECTOR(768)",
 )
-def ai_embed_768(inputs: list[str], headers) -> list[list[float]]:
-    """为输入文本生成 768 维嵌入"""
-    try:
-        # 在单个批次中处理输入
-        embeddings = model.encode(inputs)
-        # 转换为列表格式
-        return [embedding.tolist() for embedding in embeddings]
-    except Exception as e:
-        print(f"Error generating embeddings: {e}")
-        # 发生错误时返回空列表
-        return [[] for _ in inputs]
+def ai_embed_768(text: str) -> list[float]:
+    """为输入文本生成 768 维嵌入。"""
+    embedding = model.encode(
+        text or "",
+        normalize_embeddings=True,
+        show_progress_bar=False,
+    )
+    return embedding.tolist()
 
 if __name__ == '__main__':
     print("Starting embedding UDF server on port 8815...")
@@ -57,9 +54,9 @@ if __name__ == '__main__':
 
 ```sql
 -- 在 Databend 中注册外部函数
-CREATE OR REPLACE FUNCTION ai_embed_768 (STRING)
-    RETURNS ARRAY(FLOAT)
-    LANGUAGE PYTHON
+CREATE OR REPLACE FUNCTION ai_embed_768 AS (STRING)
+    RETURNS VECTOR(768)
+    LANGUAGE python
     HANDLER = 'ai_embed_768'
     ADDRESS = 'https://your-ml-server.example.com';
 

--- a/docs/cn/guides/51-ai-functions/04-document-pipeline.md
+++ b/docs/cn/guides/51-ai-functions/04-document-pipeline.md
@@ -25,9 +25,7 @@ ai_documents
 - 将 UDF 主机名加入租户的 UDF Server Allowlist。
 
 :::important[Databend Cloud 网络配置]
-执行 `CREATE FUNCTION` 前，登录 Databend Cloud，进入 **Support → Create New Ticket**，申请将 UDF 主机名（例如 `document-udf.example.com`）加入租户 **UDF Server Allowlist**。否则会返回 `Unallowed UDF server address`。
-
-Endpoint 必须使用公共信任的 TLS 证书，并支持 **基于 gRPC/HTTP2 的 Apache Arrow Flight**。普通 HTTPS/REST 或仅 HTTP/1 的反向代理无法工作。若防火墙限制入站，请向 Support 获取所在区域的 Databend Cloud 出站地址，并放通 TCP 443。
+外部函数使用 **Arrow Flight over gRPC/HTTP2**（不是 REST）。请将 UDF 以 HTTPS 暴露，并在 **Support → Create New Ticket** 中申请把主机名加入租户 **UDF Server Allowlist**；否则 `CREATE FUNCTION` 会返回 `Unallowed UDF server address`。如有防火墙限制，放通 Databend Cloud 出站地址的 TCP 443。
 :::
 
 本教程使用 `s3://my-ai-data/incoming/`。请按实际环境替换路径和凭证。

--- a/docs/cn/guides/51-ai-functions/04-document-pipeline.md
+++ b/docs/cn/guides/51-ai-functions/04-document-pipeline.md
@@ -124,13 +124,13 @@ Stage 凭证由 Databend 通过 `STAGE_LOCATION` 注入：规划阶段会把 Ext
 sudo apt-get update && sudo apt-get install -y tesseract-ocr
 
 python -m pip install \
-  'databend-udf==0.2.20' \
-  'boto3==1.43.48' \
-  'pymupdf==1.28.0' \
-  'pillow==12.3.0' \
-  'pytesseract==0.3.13' \
-  'spacy==3.8.13' \
-  'sentence-transformers==5.6.0'
+  databend-udf \
+  boto3 \
+  pymupdf \
+  pillow \
+  pytesseract \
+  spacy \
+  sentence-transformers
 python -m spacy download en_core_web_sm
 ```
 

--- a/docs/cn/guides/51-ai-functions/04-document-pipeline.md
+++ b/docs/cn/guides/51-ai-functions/04-document-pipeline.md
@@ -1,0 +1,590 @@
+---
+title: AI 文档处理流水线
+sidebar_position: 4
+---
+
+在 Databend Cloud 中搭建一条流水线：把 S3 中的 PDF / 图片变成可检索文档。
+
+```text
+S3 中的 PDF / PNG / JPG
+        ↓ COPY INTO（去重 + OCR）
+document_raw → document_raw_stream
+        ↓ Embedding Task
+ai_documents
+  ├── 倒排索引 → 全文 / 实体检索
+  └── 向量索引 → 语义检索
+```
+
+`COPY INTO` 用 Databend 的 copied-files 元数据记录已加载文件，并默认跳过已处理文件。Embedding Task 仅在 `document_raw_stream` 有新数据时运行。不需要文件清单表。
+
+## 前置条件
+
+- Databend Cloud Warehouse。请将下文 `etl_wh` 替换为实际名称。
+- 可 list / 读对象的 S3 Bucket。
+- 一台可由 Databend Cloud 通过 HTTPS Arrow Flight 访问的 Python UDF Server。
+- 将 UDF 主机名加入租户的 UDF Server Allowlist。
+
+:::important[Databend Cloud 网络配置]
+执行 `CREATE FUNCTION` 前，登录 Databend Cloud，进入 **Support → Create New Ticket**，申请将 UDF 主机名（例如 `document-udf.example.com`）加入租户 **UDF Server Allowlist**。否则会返回 `Unallowed UDF server address`。
+
+Endpoint 必须使用公共信任的 TLS 证书，并支持 **基于 gRPC/HTTP2 的 Apache Arrow Flight**。普通 HTTPS/REST 或仅 HTTP/1 的反向代理无法工作。若防火墙限制入站，请向 Support 获取所在区域的 Databend Cloud 出站地址，并放通 TCP 443。
+:::
+
+本教程使用 `s3://my-ai-data/incoming/`。请按实际环境替换路径和凭证。
+
+## 1. 上传示例文档
+
+上传任意 PDF、PNG、JPG 或 JPEG。示例合同文本：
+
+```text
+SUPPLIER AGREEMENT
+Acme Robotics signed this agreement with Northwind Logistics on July 1, 2026.
+The delivery location is Seattle, Washington.
+The total contract value is USD 125,000.
+Either party may terminate the agreement with 30 days written notice.
+```
+
+```bash
+aws s3 cp supplier-agreement.pdf \
+  s3://my-ai-data/incoming/contracts/supplier-agreement.pdf
+```
+
+路径第一段 `contracts` 会作为 `source_group`。
+
+:::important[使用不可变的对象路径]
+`COPY INTO` 按 Stage 路径去重。已处理过的对象不要原地覆盖；请在路径中加入版本号、时间戳或内容哈希，例如 `contracts/supplier-agreement-v2.pdf`。
+:::
+
+## 2. 创建 Stage、表和 Stream
+
+```sql
+CREATE DATABASE IF NOT EXISTS document_ai;
+USE document_ai;
+
+CREATE OR REPLACE CONNECTION document_s3
+    STORAGE_TYPE = 's3'
+    ACCESS_KEY_ID = '<AWS_ACCESS_KEY_ID>'
+    SECRET_ACCESS_KEY = '<AWS_SECRET_ACCESS_KEY>';
+
+CREATE OR REPLACE STAGE document_stage
+    URL = 's3://my-ai-data/incoming/'
+    CONNECTION = (CONNECTION_NAME = 'document_s3');
+
+LIST @document_stage PATTERN = '.*[.](pdf|png|jpg|jpeg)';
+```
+
+本教程使用长期有效的 Stage 静态凭证。Databend 可以通过 `STAGE_LOCATION` 参数把 External Stage 传给 UDF，因此 UDF 不必再单独配置一套 AWS Key。
+
+:::note[IAM Role / STS Stage]
+`STAGE_LOCATION` 目前要求 Stage 使用静态凭证。如果 Stage 配置了 `role_arn` 或 `security_token`，Databend 会返回 `StageLocation: @... must use a separate credential`。这种情况下，`COPY INTO` 仍可继续用 Role；UDF 需要自行具备对象读权限。
+:::
+
+```sql
+-- 每个源文件一条有效抽取记录；额外的 NULL 触发行由下游过滤。
+CREATE OR REPLACE TABLE document_raw (
+    document_id     STRING,
+    source_group    STRING,
+    file_path       STRING,
+    file_row_number UINT64,
+    extraction      VARIANT,
+    extracted_at    TIMESTAMP
+);
+
+CREATE OR REPLACE STREAM document_raw_stream
+    ON TABLE document_raw APPEND_ONLY = TRUE;
+
+CREATE OR REPLACE TABLE ai_documents (
+    document_id   STRING,
+    source_group  STRING,
+    file_path     STRING,
+    content       STRING,
+    entities      VARIANT,
+    extraction    VARIANT,
+    embedding     VECTOR(768),
+    created_at    TIMESTAMP,
+    INVERTED INDEX idx_document_search(content, extraction)
+        FILTERS = 'english_stop,english_stemmer',
+    VECTOR INDEX idx_document_embedding(embedding) distance = 'cosine'
+);
+```
+
+## 3. 启动 External UDF Server
+
+两个标量函数：
+
+- `extract_document(data_stage, path, row_number)` → OCR 文本 + 实体，可空 `VARIANT`
+- `embed_text_768(text)` → `VECTOR(768)`
+
+PDF / 图片不是结构化表格式，`COPY INTO` 仅把它们当文本扫出触发行。UDF 只在 `row_number = 0` 时下载完整对象，其余行返回 `NULL`。
+
+Stage 凭证由 Databend 通过 `STAGE_LOCATION` 注入：规划阶段会把 External Stage 序列化到 Flight Header `databend-stage-mapping`，Python SDK 再把它变成 `StageLocation` 参数。UDF 仍然需要能访问该对象存储的网络。
+
+```bash
+# Ubuntu/Debian
+sudo apt-get update && sudo apt-get install -y tesseract-ocr
+
+python -m pip install \
+  'databend-udf==0.2.20' \
+  'boto3==1.43.48' \
+  'pymupdf==1.28.0' \
+  'pillow==12.3.0' \
+  'pytesseract==0.3.13' \
+  'spacy==3.8.13' \
+  'sentence-transformers==5.6.0'
+python -m spacy download en_core_web_sm
+```
+
+```python title="document_udf_server.py"
+import io
+from pathlib import PurePosixPath
+
+import boto3
+import fitz
+import pytesseract
+import spacy
+from PIL import Image
+from databend_udf import StageLocation, UDFServer, udf
+from sentence_transformers import SentenceTransformer
+
+ner_model = spacy.load("en_core_web_sm")
+embedding_model = SentenceTransformer(
+    "sentence-transformers/all-mpnet-base-v2"
+)
+
+
+def read_pdf(data: bytes) -> str:
+    pdf = fitz.open(stream=data, filetype="pdf")
+    pages = []
+    for page in pdf:
+        text = page.get_text("text").strip()
+        if len(text) < 20:
+            pixmap = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+            image = Image.open(io.BytesIO(pixmap.tobytes("png")))
+            text = pytesseract.image_to_string(image, lang="eng").strip()
+        pages.append(text)
+    return "\n\n".join(pages)
+
+
+def read_image(data: bytes) -> str:
+    image = Image.open(io.BytesIO(data)).convert("RGB")
+    return pytesseract.image_to_string(image, lang="eng").strip()
+
+
+def s3_client(stage: StageLocation):
+    storage = stage.storage or {}
+    return boto3.client(
+        "s3",
+        region_name=storage.get("region") or None,
+        aws_access_key_id=storage.get("access_key_id") or None,
+        aws_secret_access_key=storage.get("secret_access_key") or None,
+        endpoint_url=storage.get("endpoint_url") or None,
+    )
+
+
+def object_key(stage: StageLocation, file_path: str) -> str:
+    relative = str(PurePosixPath(file_path)).lstrip("/")
+    root = (stage.storage or {}).get("root", "").strip("/")
+    prefix = stage.relative_path.strip("/")
+    return "/".join(part for part in (root, prefix, relative) if part)
+
+
+@udf(
+    stage_refs=["data_stage"],
+    input_types=["STRING", "UINT64"],
+    result_type="VARIANT NULL",
+)
+def extract_document(
+    data_stage: StageLocation,
+    file_path: str,
+    row_number: int,
+) -> dict | None:
+    # 二进制源文件可能产生多条 TEXT 触发行，仅第 0 行下载并处理完整对象。
+    if row_number != 0:
+        return None
+
+    storage = data_stage.storage or {}
+    bucket = storage.get("bucket")
+    if not bucket:
+        raise ValueError("STAGE_LOCATION is missing storage.bucket")
+
+    key = object_key(data_stage, file_path)
+    file_bytes = s3_client(data_stage).get_object(Bucket=bucket, Key=key)["Body"].read()
+    suffix = PurePosixPath(file_path).suffix.lower()
+    text = read_pdf(file_bytes) if suffix == ".pdf" else read_image(file_bytes)
+    parsed = ner_model(text)
+
+    entities = [
+        {
+            "text": entity.text,
+            "type": entity.label_,
+            "start": entity.start_char,
+            "end": entity.end_char,
+        }
+        for entity in parsed.ents
+    ]
+
+    return {
+        "text": text,
+        "entities": entities,
+        "extractor": "pymupdf+tesseract+spacy-v1",
+    }
+
+
+@udf(
+    input_types=["STRING"],
+    result_type="VECTOR(768)",
+)
+def embed_text_768(text: str) -> list[float]:
+    return embedding_model.encode(
+        text or "",
+        normalize_embeddings=True,
+    ).tolist()
+
+
+if __name__ == "__main__":
+    server = UDFServer("0.0.0.0:8815")
+    server.add_function(extract_document)
+    server.add_function(embed_text_768)
+    server.serve()
+```
+
+```bash
+python document_udf_server.py
+```
+
+`UDFServer` 在 `8815` 监听未加密 gRPC。前面请接支持 gRPC/HTTP2 的 TLS 代理，只对外开放 `443`：
+
+```text
+Databend Cloud → https://document-udf.example.com:443
+               → TLS/gRPC load balancer
+               → document_udf_server.py:8815
+```
+
+主机名加入 Allowlist 后注册函数。`STAGE_LOCATION` 必须是命名参数。`CREATE FUNCTION` 成功也意味着 DNS、TLS、gRPC、Handler 名称和类型均已通过校验：
+
+```sql
+CREATE OR REPLACE FUNCTION extract_document AS (
+    data_stage STAGE_LOCATION,
+    file_path STRING,
+    row_number UINT64
+)
+    RETURNS VARIANT NULL
+    LANGUAGE python
+    HANDLER = 'extract_document'
+    ADDRESS = 'https://document-udf.example.com';
+
+CREATE OR REPLACE FUNCTION embed_text_768 AS (STRING)
+    RETURNS VECTOR(768)
+    LANGUAGE python
+    HANDLER = 'embed_text_768'
+    ADDRESS = 'https://document-udf.example.com';
+
+SELECT VECTOR_DIMS(embed_text_768('supplier agreement'));
+-- 768
+```
+
+可选：为静态 Token 附加请求 Header（在网关侧校验；基础 `UDFServer` 不做鉴权）：
+
+```sql
+CREATE OR REPLACE FUNCTION embed_text_768 AS (STRING)
+    RETURNS VECTOR(768)
+    LANGUAGE python
+    HANDLER = 'embed_text_768'
+    HEADERS = ('authorization' = 'Bearer <UDF_TOKEN>')
+    ADDRESS = 'https://document-udf.example.com';
+```
+
+| 错误 | 可能原因 |
+| --- | --- |
+| `Unallowed UDF server address` | 主机名未加入 UDF Allowlist |
+| `Cannot connect to UDF Server` | DNS、防火墙、TLS 或负载均衡器 |
+| `UDF schema mismatch` | Python 装饰器类型与 SQL 类型不一致 |
+| `StageLocation: @... must use a separate credential` | Stage 使用了 `role_arn` 或 STS 临时凭证 |
+| gRPC `UNIMPLEMENTED`、HTTP 404/502 | 代理未正确转发 Arrow Flight / gRPC |
+
+## 4. 手动跑通一次
+
+### 第一步：复制并抽取
+
+```sql
+COPY INTO document_raw
+FROM (
+    SELECT
+        MD5(metadata$filename),
+        SPLIT_PART(metadata$filename, '/', 1),
+        CONCAT(metadata$filename, LEFT($1, 0)),
+        metadata$file_row_number,
+        extract_document(
+            @document_stage,
+            metadata$filename,
+            metadata$file_row_number
+        ),
+        NOW()
+    FROM @document_stage
+)
+PATTERN = '.*[.](pdf|png|jpg|jpeg)'
+FILE_FORMAT = (
+    TYPE = TEXT
+    FIELD_DELIMITER = ''
+    ENCODING_ERROR_MODE = 'REPLACE'
+);
+```
+
+说明：
+
+- `$1` 仅用于让 Stage 二进制文件成为合法 `COPY` 源；`LEFT($1, 0)` 返回空字符串。
+- `@document_stage` 是常量 `STAGE_LOCATION`。Databend 会把 Stage 存储凭证注入 UDF；UDF 再结合 `metadata$filename` 下载原始对象。
+
+```sql
+SELECT
+    file_path,
+    LEFT(extraction['text']::STRING, 300) AS text_preview,
+    extraction['entities']                AS entities
+FROM document_raw_stream
+WHERE extraction IS NOT NULL;
+```
+
+抽取结果示例：
+
+```json
+{
+  "text": "Acme Robotics signed this agreement with Northwind Logistics...",
+  "entities": [
+    {"text": "Acme Robotics", "type": "ORG", "start": 19, "end": 32},
+    {"text": "Northwind Logistics", "type": "ORG", "start": 60, "end": 79},
+    {"text": "July 1, 2026", "type": "DATE", "start": 83, "end": 95},
+    {"text": "USD 125,000", "type": "MONEY", "start": 179, "end": 190}
+  ],
+  "extractor": "pymupdf+tesseract+spacy-v1"
+}
+```
+
+### 第二步：生成 Embedding
+
+```sql
+INSERT INTO ai_documents
+SELECT
+    document_id,
+    source_group,
+    file_path,
+    extraction['text']::STRING,
+    extraction['entities'],
+    extraction,
+    embed_text_768(extraction['text']::STRING),
+    NOW()
+FROM document_raw_stream
+WHERE extraction IS NOT NULL
+  AND LENGTH(TRIM(extraction['text']::STRING)) > 0;
+```
+
+```sql
+SELECT
+    document_id,
+    file_path,
+    LEFT(content, 200) AS content_preview,
+    entities
+FROM ai_documents;
+```
+
+## 5. 自动运行
+
+一个定时导入 Task + 一个 Stream 条件触发的 Embedding Task：
+
+```sql
+CREATE OR REPLACE TASK ingest_documents
+    WAREHOUSE = 'etl_wh'
+    SCHEDULE = 1 MINUTE
+AS
+COPY INTO document_ai.document_raw
+FROM (
+    SELECT
+        MD5(metadata$filename),
+        SPLIT_PART(metadata$filename, '/', 1),
+        CONCAT(metadata$filename, LEFT($1, 0)),
+        metadata$file_row_number,
+        extract_document(
+            @document_stage,
+            metadata$filename,
+            metadata$file_row_number
+        ),
+        NOW()
+    FROM @document_stage
+)
+PATTERN = '.*[.](pdf|png|jpg|jpeg)'
+FILE_FORMAT = (
+    TYPE = TEXT
+    FIELD_DELIMITER = ''
+    ENCODING_ERROR_MODE = 'REPLACE'
+);
+```
+
+```sql
+CREATE OR REPLACE TASK embed_new_documents
+    WAREHOUSE = 'etl_wh'
+    SCHEDULE = 1 MINUTE
+    WHEN STREAM_STATUS('document_ai.document_raw_stream') = TRUE
+AS
+INSERT INTO document_ai.ai_documents
+SELECT
+    document_id,
+    source_group,
+    file_path,
+    extraction['text']::STRING,
+    extraction['entities'],
+    extraction,
+    embed_text_768(extraction['text']::STRING),
+    NOW()
+FROM document_ai.document_raw_stream
+WHERE extraction IS NOT NULL
+  AND LENGTH(TRIM(extraction['text']::STRING)) > 0;
+```
+
+```sql
+ALTER TASK ingest_documents RESUME;
+ALTER TASK embed_new_documents RESUME;
+```
+
+导入失败时，`COPY INTO` 不会提交，下次可重试。Embedding 失败时 Stream Offset 不推进，下次会重试该批。被 `WHERE` 过滤掉的 `NULL` 触发行仍会随 Offset 消费，不会积压。
+
+```text
+ingest_documents → document_raw_stream → embed_new_documents → ai_documents
+```
+
+## 6. 检索
+
+以下分数和距离均为示例值，会随索引内容和模型输出变化。
+
+### 全文检索
+
+用倒排索引在 OCR 文本中匹配关键词。适合你已经知道具体词项的场景，例如 `terminate`、`notice`。
+
+```sql
+SELECT
+    document_id,
+    file_path,
+    SCORE() AS relevance,
+    LEFT(content, 200) AS preview
+FROM ai_documents
+WHERE QUERY('content:(terminate OR termination) AND content:notice')
+ORDER BY relevance DESC;
+```
+
+```text
+file_path                                  relevance  preview
+contracts/supplier-agreement.pdf           1.42       SUPPLIER AGREEMENT Acme Robotics signed ...
+```
+
+### 实体检索
+
+检索 UDF 抽取出的结构化字段，例如机构名、日期、金额。适合做精确实体过滤，而不是自由文本关键词匹配。
+
+```sql
+SELECT document_id, file_path, entities
+FROM ai_documents
+WHERE QUERY(
+    'extraction.entities.text:"Acme Robotics" AND extraction.entities.type:ORG'
+);
+```
+
+```text
+file_path                                  matched entity
+contracts/supplier-agreement.pdf           Acme Robotics (ORG)
+```
+
+```sql
+SELECT
+    entity.value['type']::STRING AS entity_type,
+    entity.value['text']::STRING AS entity_text,
+    COUNT(*) AS document_count
+FROM ai_documents,
+LATERAL FLATTEN(input => entities) AS entity
+GROUP BY entity_type, entity_text
+ORDER BY document_count DESC;
+```
+
+```text
+entity_type  entity_text             document_count
+ORG          Acme Robotics           1
+ORG          Northwind Logistics     1
+DATE         July 1, 2026            1
+GPE          Seattle                 1
+MONEY        USD 125,000             1
+```
+
+### 语义检索
+
+把查询文本向量化后，按向量距离排序。适合措辞不同、但语义相近的查询。
+
+```sql
+WITH query_vector AS (
+    SELECT embed_text_768(
+        'contracts that require advance termination notice'
+    ) AS embedding
+)
+SELECT
+    document_id,
+    file_path,
+    COSINE_DISTANCE(doc.embedding, query.embedding) AS distance,
+    LEFT(content, 200) AS preview
+FROM ai_documents AS doc
+CROSS JOIN query_vector AS query
+ORDER BY distance
+LIMIT 10;
+```
+
+```text
+file_path                                  distance  preview
+contracts/supplier-agreement.pdf           0.18      SUPPLIER AGREEMENT Acme Robotics signed ...
+```
+
+Cosine Distance 越小，语义越接近。
+
+### 混合检索
+
+在同一条查询里组合分类过滤、关键词匹配和向量相似度。适合既要精确约束、又要语义排序的场景。
+
+```sql
+WITH query_vector AS (
+    SELECT embed_text_768(
+        'supplier contract cancellation terms'
+    ) AS embedding
+)
+SELECT
+    doc.document_id,
+    doc.file_path,
+    SCORE() AS text_score,
+    COSINE_DISTANCE(doc.embedding, query.embedding) AS vector_distance
+FROM ai_documents AS doc
+CROSS JOIN query_vector AS query
+WHERE doc.source_group = 'contracts'
+  AND QUERY('content:(terminate OR notice OR cancellation)')
+ORDER BY vector_distance, text_score DESC
+LIMIT 10;
+```
+
+```text
+file_path                                  text_score  vector_distance
+contracts/supplier-agreement.pdf           1.27        0.21
+```
+
+## 7. 监控
+
+```sql
+SHOW TASKS LIKE '%documents%';
+
+SELECT * FROM task_history('ingest_documents', 10);
+SELECT * FROM task_history('embed_new_documents', 10);
+
+SELECT COUNT(*) AS waiting_for_embedding
+FROM document_raw_stream
+WHERE extraction IS NOT NULL;
+
+LIST @document_stage PATTERN = '.*[.](pdf|png|jpg|jpeg)';
+```
+
+```sql
+ALTER TASK ingest_documents SUSPEND;
+ALTER TASK embed_new_documents SUSPEND;
+```
+
+处理较长生产文档时，建议在 Embedding 前将文本分块，并按 `document_id`、`page_number`、`chunk_id` 各存一个向量。流水线其余部分不变。

--- a/docs/cn/guides/51-ai-functions/index.md
+++ b/docs/cn/guides/51-ai-functions/index.md
@@ -31,3 +31,5 @@ MCP（Model Context Protocol）服务器让 AI 助手能够用自然语言查询
 **[MCP Client 集成](03-mcp-integration.md)** —— 将 AI 助手连接到托管的 Databend Cloud MCP Server，或为自托管 Databend 运行本地 `mcp-databend` Server
 
 **[MCP 服务器指南](02-mcp.md)** —— 使用本地 mcp-databend 构建对话式 BI 工具（也是连接自托管 Databend 的方式）
+
+**[AI 文档处理流水线](04-document-pipeline.md)** —— 将 S3 中的 PDF 和图片依次经过 OCR、实体抽取和 Embedding，最终实现全文检索和向量检索

--- a/docs/en/guides/51-ai-functions/01-external-functions.md
+++ b/docs/en/guides/51-ai-functions/01-external-functions.md
@@ -24,15 +24,15 @@ Build powerful AI/ML capabilities by connecting Databend with your own infrastru
 
 ## Databend Cloud Network Requirements
 
-Databend external functions use **Apache Arrow Flight over gRPC/HTTP2**, not a REST API. For Databend Cloud:
+External functions use **Arrow Flight over gRPC/HTTP2**, not REST.
 
-1. Deploy the UDF server behind an HTTPS endpoint with a publicly trusted TLS certificate and gRPC/HTTP2 support.
-2. In the Cloud console, select **Support → Create New Ticket** and ask for the endpoint hostname to be added to your tenant's **UDF server allowlist**.
-3. If your firewall restricts inbound traffic, ask Support for your region's Databend Cloud egress addresses and allow them on TCP port 443.
+1. Expose the UDF server on HTTPS with a public TLS certificate and gRPC/HTTP2 support.
+2. Open **Support → Create New Ticket** and add the hostname to the tenant **UDF server allowlist**.
+3. If the firewall is locked down, allow Databend Cloud egress addresses on TCP 443.
 
-The allowlist matches the URL hostname. A missing entry causes `CREATE FUNCTION` to fail with `Unallowed UDF server address`. `CREATE FUNCTION` also connects to the endpoint immediately and verifies the remote Arrow schema, so the endpoint must be online before registration.
+`CREATE FUNCTION` fails with `Unallowed UDF server address` until the host is allowlisted, and it also verifies the remote schema, so the endpoint must be online.
 
-The Python `UDFServer` listens for unencrypted gRPC by default. Keep that listener private and terminate TLS at a gRPC-capable load balancer or reverse proxy:
+Keep the local `UDFServer` gRPC listener private; terminate TLS at a gRPC load balancer:
 
 ```text
 Databend Cloud → HTTPS/HTTP2 :443 → UDFServer gRPC :8815

--- a/docs/en/guides/51-ai-functions/01-external-functions.md
+++ b/docs/en/guides/51-ai-functions/01-external-functions.md
@@ -24,7 +24,7 @@ Build powerful AI/ML capabilities by connecting Databend with your own infrastru
 
 ## Databend Cloud Network Requirements
 
-Databend external functions use **Apache Arrow Flight over gRPC/HTTP2**, not a REST API. The example below uses `databend-udf==0.2.20`. For Databend Cloud:
+Databend external functions use **Apache Arrow Flight over gRPC/HTTP2**, not a REST API. For Databend Cloud:
 
 1. Deploy the UDF server behind an HTTPS endpoint with a publicly trusted TLS certificate and gRPC/HTTP2 support.
 2. In the Cloud console, select **Support → Create New Ticket** and ask for the endpoint hostname to be added to your tenant's **UDF server allowlist**.

--- a/docs/en/guides/51-ai-functions/01-external-functions.md
+++ b/docs/en/guides/51-ai-functions/01-external-functions.md
@@ -22,6 +22,22 @@ Build powerful AI/ML capabilities by connecting Databend with your own infrastru
 2. **Register Function**: Connect your server to Databend with `CREATE FUNCTION`
 3. **Use in SQL**: Call your custom AI functions directly in SQL queries
 
+## Databend Cloud Network Requirements
+
+Databend external functions use **Apache Arrow Flight over gRPC/HTTP2**, not a REST API. The example below uses `databend-udf==0.2.20`. For Databend Cloud:
+
+1. Deploy the UDF server behind an HTTPS endpoint with a publicly trusted TLS certificate and gRPC/HTTP2 support.
+2. In the Cloud console, select **Support → Create New Ticket** and ask for the endpoint hostname to be added to your tenant's **UDF server allowlist**.
+3. If your firewall restricts inbound traffic, ask Support for your region's Databend Cloud egress addresses and allow them on TCP port 443.
+
+The allowlist matches the URL hostname. A missing entry causes `CREATE FUNCTION` to fail with `Unallowed UDF server address`. `CREATE FUNCTION` also connects to the endpoint immediately and verifies the remote Arrow schema, so the endpoint must be online before registration.
+
+The Python `UDFServer` listens for unencrypted gRPC by default. Keep that listener private and terminate TLS at a gRPC-capable load balancer or reverse proxy:
+
+```text
+Databend Cloud → HTTPS/HTTP2 :443 → UDFServer gRPC :8815
+```
+
 ## Example: Text Embedding Function
 
 ```python
@@ -34,19 +50,16 @@ model = SentenceTransformer('all-mpnet-base-v2')  # 768-dimensional vectors
 
 @udf(
     input_types=["STRING"],
-    result_type="ARRAY(FLOAT)",
+    result_type="VECTOR(768)",
 )
-def ai_embed_768(inputs: list[str], headers) -> list[list[float]]:
-    """Generate 768-dimensional embeddings for input texts"""
-    try:
-        # Process inputs in a single batch
-        embeddings = model.encode(inputs)
-        # Convert to list format
-        return [embedding.tolist() for embedding in embeddings]
-    except Exception as e:
-        print(f"Error generating embeddings: {e}")
-        # Return empty lists in case of error
-        return [[] for _ in inputs]
+def ai_embed_768(text: str) -> list[float]:
+    """Generate a 768-dimensional embedding for the input text."""
+    embedding = model.encode(
+        text or "",
+        normalize_embeddings=True,
+        show_progress_bar=False,
+    )
+    return embedding.tolist()
 
 if __name__ == '__main__':
     print("Starting embedding UDF server on port 8815...")
@@ -57,11 +70,15 @@ if __name__ == '__main__':
 
 ```sql
 -- Register the external function in Databend
-CREATE OR REPLACE FUNCTION ai_embed_768 (STRING)
-    RETURNS ARRAY(FLOAT)
-    LANGUAGE PYTHON
+CREATE OR REPLACE FUNCTION ai_embed_768 AS (STRING)
+    RETURNS VECTOR(768)
+    LANGUAGE python
     HANDLER = 'ai_embed_768'
     ADDRESS = 'https://your-ml-server.example.com';
+
+-- Registration connects to the Flight endpoint and validates its schema.
+SELECT VECTOR_DIMS(ai_embed_768('health check'));
+-- 768
 
 -- Use the custom embedding in queries
 SELECT

--- a/docs/en/guides/51-ai-functions/04-document-pipeline.md
+++ b/docs/en/guides/51-ai-functions/04-document-pipeline.md
@@ -1,0 +1,591 @@
+---
+title: AI Document Pipeline
+sidebar_position: 4
+---
+
+Build a pipeline that turns PDFs and images in S3 into searchable documents:
+
+```text
+PDF / PNG / JPG in S3
+        ↓ COPY INTO (dedup + OCR)
+document_raw → document_raw_stream
+        ↓ Embedding task
+ai_documents
+  ├── Inverted index → full-text / entity search
+  └── Vector index   → semantic search
+```
+
+`COPY INTO` records loaded files in Databend's copied-files metadata and skips already-loaded files by default. The embedding task runs only when `document_raw_stream` has new rows. No file-manifest table is required.
+
+## Prerequisites
+
+- A Databend Cloud warehouse. Replace `etl_wh` below with its name.
+- An S3 bucket with list and read permission.
+- A Python UDF server exposed to Databend Cloud over HTTPS Arrow Flight.
+- The UDF hostname added to your tenant's UDF server allowlist.
+
+:::important[Databend Cloud network setup]
+Before `CREATE FUNCTION`, open **Support → Create New Ticket** and ask Databend Cloud to add the UDF hostname (for example `document-udf.example.com`) to the tenant **UDF server allowlist**. Otherwise you get `Unallowed UDF server address`.
+
+The endpoint needs a public TLS certificate and **Apache Arrow Flight over gRPC/HTTP2**. Plain HTTPS/REST or HTTP/1-only proxies will not work. If the firewall is locked down, ask Support for your region's Databend Cloud egress addresses and allow TCP 443.
+:::
+
+This tutorial uses `s3://my-ai-data/incoming/`. Replace the path and credentials for your environment.
+
+## 1. Upload a Sample Document
+
+Upload any PDF, PNG, JPG, or JPEG. Example contract text:
+
+```text
+SUPPLIER AGREEMENT
+Acme Robotics signed this agreement with Northwind Logistics on July 1, 2026.
+The delivery location is Seattle, Washington.
+The total contract value is USD 125,000.
+Either party may terminate the agreement with 30 days written notice.
+```
+
+```bash
+aws s3 cp supplier-agreement.pdf \
+  s3://my-ai-data/incoming/contracts/supplier-agreement.pdf
+```
+
+The first path segment (`contracts`) becomes `source_group`.
+
+:::important[Use immutable object keys]
+`COPY INTO` deduplicates by staged path. Do not overwrite an existing key after processing. Use a version, timestamp, or content hash, for example `contracts/supplier-agreement-v2.pdf`.
+:::
+
+## 2. Create the Stage and Tables
+
+```sql
+CREATE DATABASE IF NOT EXISTS document_ai;
+USE document_ai;
+
+CREATE OR REPLACE CONNECTION document_s3
+    STORAGE_TYPE = 's3'
+    ACCESS_KEY_ID = '<AWS_ACCESS_KEY_ID>'
+    SECRET_ACCESS_KEY = '<AWS_SECRET_ACCESS_KEY>';
+
+CREATE OR REPLACE STAGE document_stage
+    URL = 's3://my-ai-data/incoming/'
+    CONNECTION = (CONNECTION_NAME = 'document_s3');
+
+LIST @document_stage PATTERN = '.*[.](pdf|png|jpg|jpeg)';
+```
+
+Use long-lived stage credentials for this tutorial. Databend can pass that External Stage into the UDF through a `STAGE_LOCATION` parameter, so the UDF does not need a second set of AWS keys.
+
+:::note[IAM Role / STS stages]
+`STAGE_LOCATION` currently requires static stage credentials. If the stage uses `role_arn` or `security_token`, Databend returns `StageLocation: @... must use a separate credential`. In that case, keep Role-based access for `COPY INTO`, and give the UDF its own read permission instead.
+:::
+
+```sql
+-- One useful extraction row per file; extra NULL trigger rows are filtered later.
+CREATE OR REPLACE TABLE document_raw (
+    document_id     STRING,
+    source_group    STRING,
+    file_path       STRING,
+    file_row_number UINT64,
+    extraction      VARIANT,
+    extracted_at    TIMESTAMP
+);
+
+CREATE OR REPLACE STREAM document_raw_stream
+    ON TABLE document_raw APPEND_ONLY = TRUE;
+
+CREATE OR REPLACE TABLE ai_documents (
+    document_id   STRING,
+    source_group  STRING,
+    file_path     STRING,
+    content       STRING,
+    entities      VARIANT,
+    extraction    VARIANT,
+    embedding     VECTOR(768),
+    created_at    TIMESTAMP,
+    INVERTED INDEX idx_document_search(content, extraction)
+        FILTERS = 'english_stop,english_stemmer',
+    VECTOR INDEX idx_document_embedding(embedding) distance = 'cosine'
+);
+```
+
+## 3. Start the External UDF Server
+
+Two scalar functions:
+
+- `extract_document(data_stage, path, row_number)` → OCR text + entities as nullable `VARIANT`
+- `embed_text_768(text)` → `VECTOR(768)`
+
+PDF and image files are not structured table formats, so `COPY INTO` scans them as text only to produce trigger rows. The UDF downloads the real object only when `row_number = 0` and returns `NULL` for other rows.
+
+The stage credentials come from Databend through the `STAGE_LOCATION` parameter. Databend serializes the External Stage into the Flight header `databend-stage-mapping`; the Python SDK injects it as a `StageLocation` argument. The UDF still needs network access to the object store.
+
+```bash
+# Ubuntu/Debian
+sudo apt-get update && sudo apt-get install -y tesseract-ocr
+
+python -m pip install \
+  'databend-udf==0.2.20' \
+  'boto3==1.43.48' \
+  'pymupdf==1.28.0' \
+  'pillow==12.3.0' \
+  'pytesseract==0.3.13' \
+  'spacy==3.8.13' \
+  'sentence-transformers==5.6.0'
+python -m spacy download en_core_web_sm
+```
+
+```python title="document_udf_server.py"
+import io
+from pathlib import PurePosixPath
+
+import boto3
+import fitz
+import pytesseract
+import spacy
+from PIL import Image
+from databend_udf import StageLocation, UDFServer, udf
+from sentence_transformers import SentenceTransformer
+
+ner_model = spacy.load("en_core_web_sm")
+embedding_model = SentenceTransformer(
+    "sentence-transformers/all-mpnet-base-v2"
+)
+
+
+def read_pdf(data: bytes) -> str:
+    pdf = fitz.open(stream=data, filetype="pdf")
+    pages = []
+    for page in pdf:
+        text = page.get_text("text").strip()
+        if len(text) < 20:
+            pixmap = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+            image = Image.open(io.BytesIO(pixmap.tobytes("png")))
+            text = pytesseract.image_to_string(image, lang="eng").strip()
+        pages.append(text)
+    return "\n\n".join(pages)
+
+
+def read_image(data: bytes) -> str:
+    image = Image.open(io.BytesIO(data)).convert("RGB")
+    return pytesseract.image_to_string(image, lang="eng").strip()
+
+
+def s3_client(stage: StageLocation):
+    storage = stage.storage or {}
+    return boto3.client(
+        "s3",
+        region_name=storage.get("region") or None,
+        aws_access_key_id=storage.get("access_key_id") or None,
+        aws_secret_access_key=storage.get("secret_access_key") or None,
+        endpoint_url=storage.get("endpoint_url") or None,
+    )
+
+
+def object_key(stage: StageLocation, file_path: str) -> str:
+    relative = str(PurePosixPath(file_path)).lstrip("/")
+    root = (stage.storage or {}).get("root", "").strip("/")
+    prefix = stage.relative_path.strip("/")
+    return "/".join(part for part in (root, prefix, relative) if part)
+
+
+@udf(
+    stage_refs=["data_stage"],
+    input_types=["STRING", "UINT64"],
+    result_type="VARIANT NULL",
+)
+def extract_document(
+    data_stage: StageLocation,
+    file_path: str,
+    row_number: int,
+) -> dict | None:
+    # Binary sources can produce several TEXT trigger rows. Only row 0
+    # downloads and processes the complete object.
+    if row_number != 0:
+        return None
+
+    storage = data_stage.storage or {}
+    bucket = storage.get("bucket")
+    if not bucket:
+        raise ValueError("STAGE_LOCATION is missing storage.bucket")
+
+    key = object_key(data_stage, file_path)
+    file_bytes = s3_client(data_stage).get_object(Bucket=bucket, Key=key)["Body"].read()
+    suffix = PurePosixPath(file_path).suffix.lower()
+    text = read_pdf(file_bytes) if suffix == ".pdf" else read_image(file_bytes)
+    parsed = ner_model(text)
+
+    entities = [
+        {
+            "text": entity.text,
+            "type": entity.label_,
+            "start": entity.start_char,
+            "end": entity.end_char,
+        }
+        for entity in parsed.ents
+    ]
+
+    return {
+        "text": text,
+        "entities": entities,
+        "extractor": "pymupdf+tesseract+spacy-v1",
+    }
+
+
+@udf(
+    input_types=["STRING"],
+    result_type="VECTOR(768)",
+)
+def embed_text_768(text: str) -> list[float]:
+    return embedding_model.encode(
+        text or "",
+        normalize_embeddings=True,
+    ).tolist()
+
+
+if __name__ == "__main__":
+    server = UDFServer("0.0.0.0:8815")
+    server.add_function(extract_document)
+    server.add_function(embed_text_768)
+    server.serve()
+```
+
+```bash
+python document_udf_server.py
+```
+
+`UDFServer` listens for unencrypted gRPC on `8815`. Put TLS + gRPC/HTTP2 in front of it and expose only `443`:
+
+```text
+Databend Cloud → https://document-udf.example.com:443
+               → TLS/gRPC load balancer
+               → document_udf_server.py:8815
+```
+
+Register the functions after the hostname is on the allowlist. `STAGE_LOCATION` must be a named parameter. A successful `CREATE FUNCTION` also verifies DNS, TLS, gRPC routing, handler name, and types:
+
+```sql
+CREATE OR REPLACE FUNCTION extract_document AS (
+    data_stage STAGE_LOCATION,
+    file_path STRING,
+    row_number UINT64
+)
+    RETURNS VARIANT NULL
+    LANGUAGE python
+    HANDLER = 'extract_document'
+    ADDRESS = 'https://document-udf.example.com';
+
+CREATE OR REPLACE FUNCTION embed_text_768 AS (STRING)
+    RETURNS VECTOR(768)
+    LANGUAGE python
+    HANDLER = 'embed_text_768'
+    ADDRESS = 'https://document-udf.example.com';
+
+SELECT VECTOR_DIMS(embed_text_768('supplier agreement'));
+-- 768
+```
+
+Optional request header for a static token (validate it at the gateway; base `UDFServer` does not authenticate):
+
+```sql
+CREATE OR REPLACE FUNCTION embed_text_768 AS (STRING)
+    RETURNS VECTOR(768)
+    LANGUAGE python
+    HANDLER = 'embed_text_768'
+    HEADERS = ('authorization' = 'Bearer <UDF_TOKEN>')
+    ADDRESS = 'https://document-udf.example.com';
+```
+
+| Error | Likely cause |
+| --- | --- |
+| `Unallowed UDF server address` | Hostname not on the UDF allowlist |
+| `Cannot connect to UDF Server` | DNS, firewall, TLS, or load balancer |
+| `UDF schema mismatch` | Python decorator types ≠ SQL types |
+| `StageLocation: @... must use a separate credential` | Stage uses `role_arn` or STS temporary credentials |
+| gRPC `UNIMPLEMENTED`, HTTP 404/502 | Proxy is not forwarding Arrow Flight / gRPC |
+
+## 4. Run Once Manually
+
+### Step 1: Copy and extract
+
+```sql
+COPY INTO document_raw
+FROM (
+    SELECT
+        MD5(metadata$filename),
+        SPLIT_PART(metadata$filename, '/', 1),
+        CONCAT(metadata$filename, LEFT($1, 0)),
+        metadata$file_row_number,
+        extract_document(
+            @document_stage,
+            metadata$filename,
+            metadata$file_row_number
+        ),
+        NOW()
+    FROM @document_stage
+)
+PATTERN = '.*[.](pdf|png|jpg|jpeg)'
+FILE_FORMAT = (
+    TYPE = TEXT
+    FIELD_DELIMITER = ''
+    ENCODING_ERROR_MODE = 'REPLACE'
+);
+```
+
+Notes:
+
+- `$1` is only referenced so the staged binary becomes a valid `COPY` source; `LEFT($1, 0)` contributes an empty string.
+- `@document_stage` is a constant `STAGE_LOCATION`. Databend injects its storage credentials into the UDF; the UDF downloads the original object with `metadata$filename`.
+
+```sql
+SELECT
+    file_path,
+    LEFT(extraction['text']::STRING, 300) AS text_preview,
+    extraction['entities']                AS entities
+FROM document_raw_stream
+WHERE extraction IS NOT NULL;
+```
+
+Example extraction:
+
+```json
+{
+  "text": "Acme Robotics signed this agreement with Northwind Logistics...",
+  "entities": [
+    {"text": "Acme Robotics", "type": "ORG", "start": 19, "end": 32},
+    {"text": "Northwind Logistics", "type": "ORG", "start": 60, "end": 79},
+    {"text": "July 1, 2026", "type": "DATE", "start": 83, "end": 95},
+    {"text": "USD 125,000", "type": "MONEY", "start": 179, "end": 190}
+  ],
+  "extractor": "pymupdf+tesseract+spacy-v1"
+}
+```
+
+### Step 2: Embed
+
+```sql
+INSERT INTO ai_documents
+SELECT
+    document_id,
+    source_group,
+    file_path,
+    extraction['text']::STRING,
+    extraction['entities'],
+    extraction,
+    embed_text_768(extraction['text']::STRING),
+    NOW()
+FROM document_raw_stream
+WHERE extraction IS NOT NULL
+  AND LENGTH(TRIM(extraction['text']::STRING)) > 0;
+```
+
+```sql
+SELECT
+    document_id,
+    file_path,
+    LEFT(content, 200) AS content_preview,
+    entities
+FROM ai_documents;
+```
+
+## 5. Automate
+
+One scheduled ingestion task and one stream-triggered embedding task:
+
+```sql
+CREATE OR REPLACE TASK ingest_documents
+    WAREHOUSE = 'etl_wh'
+    SCHEDULE = 1 MINUTE
+AS
+COPY INTO document_ai.document_raw
+FROM (
+    SELECT
+        MD5(metadata$filename),
+        SPLIT_PART(metadata$filename, '/', 1),
+        CONCAT(metadata$filename, LEFT($1, 0)),
+        metadata$file_row_number,
+        extract_document(
+            @document_stage,
+            metadata$filename,
+            metadata$file_row_number
+        ),
+        NOW()
+    FROM @document_stage
+)
+PATTERN = '.*[.](pdf|png|jpg|jpeg)'
+FILE_FORMAT = (
+    TYPE = TEXT
+    FIELD_DELIMITER = ''
+    ENCODING_ERROR_MODE = 'REPLACE'
+);
+```
+
+```sql
+CREATE OR REPLACE TASK embed_new_documents
+    WAREHOUSE = 'etl_wh'
+    SCHEDULE = 1 MINUTE
+    WHEN STREAM_STATUS('document_ai.document_raw_stream') = TRUE
+AS
+INSERT INTO document_ai.ai_documents
+SELECT
+    document_id,
+    source_group,
+    file_path,
+    extraction['text']::STRING,
+    extraction['entities'],
+    extraction,
+    embed_text_768(extraction['text']::STRING),
+    NOW()
+FROM document_ai.document_raw_stream
+WHERE extraction IS NOT NULL
+  AND LENGTH(TRIM(extraction['text']::STRING)) > 0;
+```
+
+```sql
+ALTER TASK ingest_documents RESUME;
+ALTER TASK embed_new_documents RESUME;
+```
+
+If ingestion fails, `COPY INTO` does not commit, so the next run retries. If embedding fails, the stream offset does not advance, so the next run retries that batch. Filtered `NULL` trigger rows are still consumed with the stream offset and do not accumulate.
+
+```text
+ingest_documents → document_raw_stream → embed_new_documents → ai_documents
+```
+
+## 6. Search
+
+Scores and distances below are illustrative; they vary with index contents and model output.
+
+### Full-text
+
+Match keywords in the OCR text with the inverted index. Use this when you know the exact terms, such as `terminate` and `notice`.
+
+```sql
+SELECT
+    document_id,
+    file_path,
+    SCORE() AS relevance,
+    LEFT(content, 200) AS preview
+FROM ai_documents
+WHERE QUERY('content:(terminate OR termination) AND content:notice')
+ORDER BY relevance DESC;
+```
+
+```text
+file_path                                  relevance  preview
+contracts/supplier-agreement.pdf           1.42       SUPPLIER AGREEMENT Acme Robotics signed ...
+```
+
+### Entities
+
+Search structured fields extracted by the UDF, such as organization names, dates, or amounts. Use this for exact entity filters rather than free-text keywords.
+
+```sql
+SELECT document_id, file_path, entities
+FROM ai_documents
+WHERE QUERY(
+    'extraction.entities.text:"Acme Robotics" AND extraction.entities.type:ORG'
+);
+```
+
+```text
+file_path                                  matched entity
+contracts/supplier-agreement.pdf           Acme Robotics (ORG)
+```
+
+```sql
+SELECT
+    entity.value['type']::STRING AS entity_type,
+    entity.value['text']::STRING AS entity_text,
+    COUNT(*) AS document_count
+FROM ai_documents,
+LATERAL FLATTEN(input => entities) AS entity
+GROUP BY entity_type, entity_text
+ORDER BY document_count DESC;
+```
+
+```text
+entity_type  entity_text             document_count
+ORG          Acme Robotics           1
+ORG          Northwind Logistics     1
+DATE         July 1, 2026            1
+GPE          Seattle                 1
+MONEY        USD 125,000             1
+```
+
+### Semantic
+
+Embed the query and rank documents by vector distance. Use this when the wording differs from the document, but the meaning is similar.
+
+```sql
+WITH query_vector AS (
+    SELECT embed_text_768(
+        'contracts that require advance termination notice'
+    ) AS embedding
+)
+SELECT
+    document_id,
+    file_path,
+    COSINE_DISTANCE(doc.embedding, query.embedding) AS distance,
+    LEFT(content, 200) AS preview
+FROM ai_documents AS doc
+CROSS JOIN query_vector AS query
+ORDER BY distance
+LIMIT 10;
+```
+
+```text
+file_path                                  distance  preview
+contracts/supplier-agreement.pdf           0.18      SUPPLIER AGREEMENT Acme Robotics signed ...
+```
+
+Lower cosine distance means closer semantic match.
+
+### Hybrid
+
+Combine a category filter, keyword match, and vector similarity in one query. Use this when you want both exact constraints and semantic ranking.
+
+```sql
+WITH query_vector AS (
+    SELECT embed_text_768(
+        'supplier contract cancellation terms'
+    ) AS embedding
+)
+SELECT
+    doc.document_id,
+    doc.file_path,
+    SCORE() AS text_score,
+    COSINE_DISTANCE(doc.embedding, query.embedding) AS vector_distance
+FROM ai_documents AS doc
+CROSS JOIN query_vector AS query
+WHERE doc.source_group = 'contracts'
+  AND QUERY('content:(terminate OR notice OR cancellation)')
+ORDER BY vector_distance, text_score DESC
+LIMIT 10;
+```
+
+```text
+file_path                                  text_score  vector_distance
+contracts/supplier-agreement.pdf           1.27        0.21
+```
+
+## 7. Monitor
+
+```sql
+SHOW TASKS LIKE '%documents%';
+
+SELECT * FROM task_history('ingest_documents', 10);
+SELECT * FROM task_history('embed_new_documents', 10);
+
+SELECT COUNT(*) AS waiting_for_embedding
+FROM document_raw_stream
+WHERE extraction IS NOT NULL;
+
+LIST @document_stage PATTERN = '.*[.](pdf|png|jpg|jpeg)';
+```
+
+```sql
+ALTER TASK ingest_documents SUSPEND;
+ALTER TASK embed_new_documents SUSPEND;
+```
+
+For long production documents, chunk the extracted text before embedding and store one vector per `document_id`, `page_number`, and `chunk_id`. The rest of the pipeline stays the same.

--- a/docs/en/guides/51-ai-functions/04-document-pipeline.md
+++ b/docs/en/guides/51-ai-functions/04-document-pipeline.md
@@ -124,13 +124,13 @@ The stage credentials come from Databend through the `STAGE_LOCATION` parameter.
 sudo apt-get update && sudo apt-get install -y tesseract-ocr
 
 python -m pip install \
-  'databend-udf==0.2.20' \
-  'boto3==1.43.48' \
-  'pymupdf==1.28.0' \
-  'pillow==12.3.0' \
-  'pytesseract==0.3.13' \
-  'spacy==3.8.13' \
-  'sentence-transformers==5.6.0'
+  databend-udf \
+  boto3 \
+  pymupdf \
+  pillow \
+  pytesseract \
+  spacy \
+  sentence-transformers
 python -m spacy download en_core_web_sm
 ```
 

--- a/docs/en/guides/51-ai-functions/04-document-pipeline.md
+++ b/docs/en/guides/51-ai-functions/04-document-pipeline.md
@@ -25,9 +25,7 @@ ai_documents
 - The UDF hostname added to your tenant's UDF server allowlist.
 
 :::important[Databend Cloud network setup]
-Before `CREATE FUNCTION`, open **Support → Create New Ticket** and ask Databend Cloud to add the UDF hostname (for example `document-udf.example.com`) to the tenant **UDF server allowlist**. Otherwise you get `Unallowed UDF server address`.
-
-The endpoint needs a public TLS certificate and **Apache Arrow Flight over gRPC/HTTP2**. Plain HTTPS/REST or HTTP/1-only proxies will not work. If the firewall is locked down, ask Support for your region's Databend Cloud egress addresses and allow TCP 443.
+External functions use **Arrow Flight over gRPC/HTTP2** (not REST). Expose the UDF on HTTPS, then open **Support → Create New Ticket** to add the hostname to the tenant **UDF server allowlist**. Otherwise `CREATE FUNCTION` returns `Unallowed UDF server address`. If needed, allow Databend Cloud egress on TCP 443.
 :::
 
 This tutorial uses `s3://my-ai-data/incoming/`. Replace the path and credentials for your environment.

--- a/docs/en/guides/51-ai-functions/index.md
+++ b/docs/en/guides/51-ai-functions/index.md
@@ -31,3 +31,5 @@ The Model Context Protocol (MCP) server enables AI assistants to interact with y
 **[MCP Client Integration](03-mcp-integration.md)** - Connect your AI assistant to the hosted Databend Cloud MCP server, or run the local `mcp-databend` server for self-hosted Databend
 
 **[MCP Server Guide](02-mcp.md)** - Build a conversational BI tool using the local mcp-databend server (also the way to connect self-hosted Databend)
+
+**[AI Document Pipeline](04-document-pipeline.md)** - Build an end-to-end pipeline from PDFs and images in S3 through OCR, entity extraction, embeddings, and full-text/vector search

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/11-external-function/ddl-create-function.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/11-external-function/ddl-create-function.md
@@ -52,7 +52,7 @@ from databend_udf import udf, UDFServer
 
 @udf(
     input_types=["INT", "INT"],
-    result_type="INT",
+    result_type="INT NULL",
     skip_null=True,
 )
 def gcd(x: int, y: int) -> int:
@@ -89,7 +89,7 @@ For Databend Cloud, expose the Flight server on HTTPS with gRPC/HTTP2 support, t
 
 ```sql
 CREATE FUNCTION gcd AS (INT, INT)
-    RETURNS INT
+    RETURNS INT NULL
     LANGUAGE python
     HANDLER = 'gcd'
     ADDRESS = 'http://127.0.0.1:8815';

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/11-external-function/ddl-create-function.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/11-external-function/ddl-create-function.md
@@ -39,10 +39,10 @@ This example walks through a complete end-to-end setup for an external function 
 
 ### Step 1: Set Up the Python UDF Server
 
-Install the `databend-udf` package:
+External functions communicate over Apache Arrow Flight (gRPC/HTTP2), not REST. Install the `databend-udf` package:
 
 ```bash
-pip install databend-udf
+pip install 'databend-udf==0.2.20'
 ```
 
 Create a file `udf_server.py` with the following content:
@@ -72,17 +72,30 @@ Start the server:
 python udf_server.py
 ```
 
-### Step 2: Register the Function in Databend
+### Step 2: Expose and Allow the Server
+
+For local or self-hosted testing, configure every Databend query node:
+
+```toml
+[query]
+enable_udf_server = true
+udf_server_allow_insecure = true
+udf_server_allow_list = ["http://127.0.0.1:8815"]
+```
+
+For Databend Cloud, expose the Flight server behind an HTTPS endpoint with a publicly trusted TLS certificate and gRPC/HTTP2 support. Then select **Support → Create New Ticket** in the Cloud console and ask for the endpoint hostname to be added to the tenant's **UDF server allowlist**. `CREATE FUNCTION` fails with `Unallowed UDF server address` until this is done.
+
+### Step 3: Register the Function in Databend
 
 ```sql
 CREATE FUNCTION gcd AS (INT, INT)
     RETURNS INT
     LANGUAGE python
     HANDLER = 'gcd'
-    ADDRESS = 'http://localhost:8815';
+    ADDRESS = 'http://127.0.0.1:8815';
 ```
 
-### Step 3: Call the Function
+### Step 4: Call the Function
 
 ```sql
 SELECT gcd(48, 18);

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/11-external-function/ddl-create-function.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/11-external-function/ddl-create-function.md
@@ -83,7 +83,7 @@ udf_server_allow_insecure = true
 udf_server_allow_list = ["http://127.0.0.1:8815"]
 ```
 
-For Databend Cloud, expose the Flight server behind an HTTPS endpoint with a publicly trusted TLS certificate and gRPC/HTTP2 support. Then select **Support → Create New Ticket** in the Cloud console and ask for the endpoint hostname to be added to the tenant's **UDF server allowlist**. `CREATE FUNCTION` fails with `Unallowed UDF server address` until this is done.
+For Databend Cloud, expose the Flight server on HTTPS with gRPC/HTTP2 support, then open **Support → Create New Ticket** to add the hostname to the tenant **UDF server allowlist**. Until then, `CREATE FUNCTION` fails with `Unallowed UDF server address`.
 
 ### Step 3: Register the Function in Databend
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/11-external-function/ddl-create-function.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/11-external-function/ddl-create-function.md
@@ -42,7 +42,7 @@ This example walks through a complete end-to-end setup for an external function 
 External functions communicate over Apache Arrow Flight (gRPC/HTTP2), not REST. Install the `databend-udf` package:
 
 ```bash
-pip install 'databend-udf==0.2.20'
+pip install databend-udf
 ```
 
 Create a file `udf_server.py` with the following content:

--- a/src/css/markdown.scss
+++ b/src/css/markdown.scss
@@ -256,6 +256,16 @@
   }
 }
 
+// Keep long code examples compact while preserving titles and copy buttons
+// outside the scrollable <pre> element. Short code blocks remain unchanged.
+@media screen {
+  .theme-doc-markdown.markdown div[class^="codeBlockContent_"] pre {
+    max-height: min(46.8rem, 70vh);
+    overflow-x: auto;
+    overflow-y: auto;
+  }
+}
+
 // margin
 .margin-top--lg {
   --ifm-card-border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- Add EN/CN tutorial for an AI document pipeline: S3 PDF/image → OCR + entity extraction → embeddings → full-text/vector search
- Use Databend `STAGE_LOCATION` so the external UDF reuses External Stage credentials instead of a second AWS key setup
- Update external function guides and CREATE FUNCTION reference with Cloud network / Arrow Flight requirements and `VECTOR(768)` examples
- Limit long markdown code block height so long samples scroll instead of expanding the page

## Test plan
- [x] Python UDF samples parse successfully
- [x] Local production builds for EN/CN succeed
- [x] Local preview shows tutorial under AI/ML category last item
- [x] Full-text / entity / semantic / hybrid search sections render with short intros and sample outputs
- [ ] Review PR preview for EN and CN pages