### PR TITLE
fix: switch Ask AI to DeepSeek Chat assistants

### DIFF
--- a/site-config.ts
+++ b/site-config.ts
@@ -7,7 +7,7 @@ export const siteConfig = {
     cloudLink: 'https://app.databend.cn',
     docsHomeLink: 'https://docs.databend.cn',
     algolia: {
-      askAi: 'oZ2gEdzflDvN',
+      askAi: 'RzaWYd5JMqa8',
       appId: "FUCSAUXK2Q",
       apiKey: "0f200c10999f19584ec9e31b5caa9065",
       indexName: "databend",
@@ -21,7 +21,7 @@ export const siteConfig = {
     cloudLink: 'https://app.databend.com',
     docsHomeLink: 'https://docs.databend.com',
     algolia: {
-      askAi: 'f2nql6AG9fqs',
+      askAi: 'qJl44MMtmV1W',
       appId: "XA8ZCKIEYU",
       apiKey: "81e5ee11f82ed1c5de63ef7ea0551abf",
       indexName: "databend",


### PR DESCRIPTION
## Summary
- Point CN docs (`docs.databend.cn`) Ask AI from broken `oZ2gEdzflDvN` (AI-221) to new `DeepSeek_Chat` assistant `RzaWYd5JMqa8`
- Point EN docs (`docs.databend.com`) Ask AI from `f2nql6AG9fqs` to new `DeepSeek_Chat` assistant `qJl44MMtmV1W`
- Both new assistants were created in Algolia dashboard and API-tested successfully

## Test plan
- [x] API chat test against `RzaWYd5JMqa8` with Origin `docs.databend.cn`
- [x] API chat test against `qJl44MMtmV1W` with Origin `docs.databend.com`
- [ ] After merge/deploy, verify Ask AI on https://docs.databend.cn
- [ ] After merge/deploy, verify Ask AI on https://docs.databend.com