### PR TITLE
docs: update ALTER VIEW behavior

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/05-view/ddl-alter-view.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/05-view/ddl-alter-view.md
@@ -3,45 +3,17 @@ title: ALTER VIEW
 sidebar_position: 2
 ---
 
-通过使用另一个 `QUERY` 来更改现有视图。
+import FunctionDescription from '@site/src/components/FunctionDescription';
 
-## Syntax
+<FunctionDescription description="Introduced or updated: v1.2.930"/>
 
-```sql
-ALTER VIEW [ <database_name>. ]view_name [ (<column>, ...) ] AS SELECT query
-```
+为现有视图分配或移除 Tag。Tag 必须先通过 [CREATE TAG](../08-tag/01-ddl-create-tag.md) 创建。完整说明请参阅 [SET TAG / UNSET TAG](../08-tag/04-ddl-set-tag.md)。
 
-## Examples
+:::note
+不支持 `ALTER VIEW ... AS ...`。如需更改视图的查询或输出列，请使用 [CREATE OR REPLACE VIEW](ddl-create-view.md)。
+:::
 
-```sql
-CREATE VIEW tmp_view AS SELECT number % 3 AS a, avg(number) FROM numbers(1000) GROUP BY a ORDER BY a;
-
-SELECT * FROM tmp_view;
-+------+-------------+
-| a    | avg(number) |
-+------+-------------+
-|    0 |       499.5 |
-|    1 |       499.0 |
-|    2 |       500.0 |
-+------+-------------+
-
-ALTER VIEW tmp_view(c1) AS SELECT * from numbers(3);
-
-SELECT * FROM tmp_view;
-+------+
-| c1   |
-+------+
-|    0 |
-|    1 |
-|    2 |
-+------+
-```
-
-## Tag 操作
-
-为视图分配或移除 Tag。Tag 必须先通过 [CREATE TAG](../08-tag/01-ddl-create-tag.md) 创建。完整说明请参阅 [SET TAG / UNSET TAG](../08-tag/04-ddl-set-tag.md)。
-
-### 语法
+## 语法
 
 ```sql
 ALTER VIEW [ IF EXISTS ] [ <database_name>. ]<view_name>
@@ -51,7 +23,7 @@ ALTER VIEW [ IF EXISTS ] [ <database_name>. ]<view_name>
     UNSET TAG <tag_name> [, <tag_name> ...]
 ```
 
-### 示例
+## 示例
 
 ```sql
 ALTER VIEW default.active_users SET TAG env = 'prod', owner = 'analytics';

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/05-view/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/05-view/index.md
@@ -9,7 +9,7 @@ title: 视图（View）
 | 命令 | 描述 |
 |---------|-------------|
 | [CREATE VIEW](ddl-create-view.md) | 基于查询创建新视图 |
-| [ALTER VIEW](ddl-alter-view.md) | 修改现有视图 |
+| [ALTER VIEW](ddl-alter-view.md) | 为现有视图分配或移除 Tag |
 | [DROP VIEW](ddl-drop-view.md) | 删除视图 |
 
 ## 视图信息

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/05-view/ddl-alter-view.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/05-view/ddl-alter-view.md
@@ -3,45 +3,17 @@ title: ALTER VIEW
 sidebar_position: 2
 ---
 
-Alter the existing view by using another `QUERY`.
+import FunctionDescription from '@site/src/components/FunctionDescription';
+
+<FunctionDescription description="Introduced or updated: v1.2.930"/>
+
+Assigns or removes tags on an existing view. Tags must be created with [CREATE TAG](../08-tag/01-ddl-create-tag.md) first. For full details, see [SET TAG / UNSET TAG](../08-tag/04-ddl-set-tag.md).
+
+:::note
+`ALTER VIEW ... AS ...` is not supported. To change a view's query or output columns, use [CREATE OR REPLACE VIEW](ddl-create-view.md).
+:::
 
 ## Syntax
-
-```sql
-ALTER VIEW [ <database_name>. ]view_name [ (<column>, ...) ] AS SELECT query
-```
-
-## Examples
-
-```sql
-CREATE VIEW tmp_view AS SELECT number % 3 AS a, avg(number) FROM numbers(1000) GROUP BY a ORDER BY a;
-
-SELECT * FROM tmp_view;
-+------+-------------+
-| a    | avg(number) |
-+------+-------------+
-|    0 |       499.5 |
-|    1 |       499.0 |
-|    2 |       500.0 |
-+------+-------------+
-
-ALTER VIEW tmp_view(c1) AS SELECT * from numbers(3);
-
-SELECT * FROM tmp_view;
-+------+
-| c1   |
-+------+
-|    0 |
-|    1 |
-|    2 |
-+------+
-```
-
-## Tag Operations
-
-Assigns or removes tags on a view. Tags must be created with [CREATE TAG](../08-tag/01-ddl-create-tag.md) first. For full details, see [SET TAG / UNSET TAG](../08-tag/04-ddl-set-tag.md).
-
-### Syntax
 
 ```sql
 ALTER VIEW [ IF EXISTS ] [ <database_name>. ]<view_name>
@@ -51,7 +23,7 @@ ALTER VIEW [ IF EXISTS ] [ <database_name>. ]<view_name>
     UNSET TAG <tag_name> [, <tag_name> ...]
 ```
 
-### Examples
+## Examples
 
 ```sql
 ALTER VIEW default.active_users SET TAG env = 'prod', owner = 'analytics';

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/05-view/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/05-view/index.md
@@ -9,7 +9,7 @@ This page provides a comprehensive overview of view operations in Databend, orga
 | Command | Description |
 |---------|-------------|
 | [CREATE VIEW](ddl-create-view.md) | Creates a new view based on a query |
-| [ALTER VIEW](ddl-alter-view.md) | Modifies an existing view |
+| [ALTER VIEW](ddl-alter-view.md) | Assigns or removes tags on an existing view |
 | [DROP VIEW](ddl-drop-view.md) | Removes a view |
 
 ## View Information


### PR DESCRIPTION
## Summary

Documentation update for:

- databendlabs/databend#20202: feat(query): reject alter view definition changes

This update removes the unsupported `ALTER VIEW ... AS ...` syntax and examples while retaining the still-supported `SET TAG` and `UNSET TAG` operations.

## Motivation

Databend now rejects changes to a view's stored query or output-column definition through `ALTER VIEW`. Keeping the old syntax and successful examples would direct users to a command that returns `Unimplemented`. The replacement guidance now points users to `CREATE OR REPLACE VIEW`, while preserving the valid tag-management use case.

## Changes

- Remove view-definition replacement syntax, parameters, results, and examples.
- Document `ALTER VIEW` as a tag-management command only.
- Add guidance to use `CREATE OR REPLACE VIEW` for query or output-column changes.
- Update the English and Chinese view indexes.

## Languages

- [x] English (`docs/en/`)
- [x] Chinese (`docs/cn/`)

## Testing

- [x] English Docusaurus production build
- [x] Chinese Docusaurus production build
- [x] `git diff --check`

## SQL Validation Checklist

- [x] Retained SQL examples validated via Databend Cloud: 2/2 passed
- [x] `SET TAG` result verified: both tags were attached to the view
- [x] `UNSET TAG` result verified: no tags remained on the view
- [x] Definition-change rejection verified against the latest Databend `main` binder and sqllogictest coverage

## Related

- Source PR: https://github.com/databendlabs/databend/pull/20202
