### PR TITLE
docs: restore WASM UDF workflow

### DIFF
--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/10-udf/ddl-create-function.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/10-udf/ddl-create-function.md
@@ -4,9 +4,13 @@ sidebar_position: 0
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="引入或更新于：SQL v1.2.799；Python/JavaScript v1.2.339"/>
+<FunctionDescription description="引入或更新于：SQL v1.2.799；Python/JavaScript v1.2.339；WASM v1.2.936"/>
 
-创建标量用户自定义函数（Scalar UDF）。同一条 `CREATE FUNCTION` 语句既可以用 SQL 表达式来写逻辑，也可以用 Python / JavaScript 写代码，并通过 `HANDLER` 指定入口函数。
+创建标量用户自定义函数（Scalar UDF）。同一条 `CREATE FUNCTION` 语句支持以下三种实现方式：
+
+- **SQL 表达式**：完全使用 SQL 编写逻辑，不需要外部运行时。
+- **Python / JavaScript**：编写代码，并通过 `HANDLER` 指定入口函数。
+- **WebAssembly（WASM）**：将 Rust 函数编译为 WASM 模块、上传到 Stage，再通过 `HANDLER` 指定入口函数。
 
 如果你要调用外部系统（HTTP/服务），请参考外部函数（External Function）相关命令。
 
@@ -36,16 +40,29 @@ CREATE [ OR REPLACE ] FUNCTION [ IF NOT EXISTS ] <function_name>
     [ DESC='<description>' ]
 ```
 
+### WebAssembly（WASM）
+
+```sql
+CREATE [ OR REPLACE ] FUNCTION [ IF NOT EXISTS ] <function_name>
+    ( [<parameter_list>] )
+    RETURNS <return_type>
+    LANGUAGE wasm
+    HANDLER = '<handler_name>'
+    AS $$<stage_path>$$
+    [ DESC='<description>' ]
+```
+
 ## 参数说明
 
 - `<parameter_list>`：可选的逗号分隔参数列表及其类型（例如 `x INT, y FLOAT`）
 - `<return_type>`：函数返回值的数据类型
 - `<expression>`：仅 SQL 方式使用，用于定义函数逻辑的 SQL 表达式
-- `<language>`：仅 Python/JavaScript 方式使用，取值为 `python` 或 `javascript`
+- `<language>`：取值为 `python`、`javascript` 或 `wasm`
 - `<import_path>`：仅 Python/JavaScript 方式可选，用于导入 Stage 文件（例如 `@s_udf/your_file.zip`）
 - `<package_name>`：仅 Python 方式可选，用于从 PyPI 安装依赖（例如 `numpy`）
-- `<handler_name>`：仅 Python/JavaScript 方式使用，代码中作为入口的函数名
+- `<handler_name>`：要调用的函数名。WASM 方式只填写 Rust 入口函数名，不要填写完整的 Arrow UDF 签名
 - `<function_code>`：仅 Python/JavaScript 方式使用，对应语言的实现代码
+- `<stage_path>`：Stage 中已编译 WASM 模块的路径（例如 `@wasm_udf_stage/wasm_udf_example.wasm`）
 
 ## 访问控制要求
 
@@ -185,3 +202,87 @@ export function calculateAge(birthDateStr) {
 }
 $$;
 ```
+
+## WebAssembly（WASM）
+
+WASM UDF 支持使用 Rust 实现标量函数，并在 Databend 中直接运行编译后的模块。模块使用的 Arrow UDF 版本必须与 Databend 版本兼容。
+
+以下示例将构建并注册一个计算最大公约数的函数。
+
+### 1. 创建 Rust 项目
+
+安装 WASI Preview 1 编译目标，并创建一个库 crate：
+
+```bash
+rustup target add wasm32-wasip1
+cargo new --lib wasm-udf-example
+cd wasm-udf-example
+```
+
+`wasm32-wasip1` 是 Rust 对原 `wasm32-wasi` 编译目标的现用名称。
+
+将 `Cargo.toml` 替换为以下配置。锁定的 Arrow UDF revision 与 Databend v1.2.936 匹配：
+
+```toml
+[package]
+name = "wasm-udf-example"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+arrow-udf = { git = "https://github.com/datafuse-extras/arrow-udf.git", rev = "c1de708add62ecd1afa2721b2e5c639f29be1f9d" }
+```
+
+### 2. 实现函数
+
+将 `src/lib.rs` 替换为：
+
+```rust
+use arrow_udf::function;
+
+#[function("wasm_gcd(int, int) -> int")]
+fn wasm_gcd(mut a: i32, mut b: i32) -> i32 {
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}
+```
+
+### 3. 构建并上传模块
+
+```bash
+cargo build --release --target wasm32-wasip1
+```
+
+编译后的模块位于 `target/wasm32-wasip1/release/wasm_udf_example.wasm`。使用绝对本地路径将其上传到 Databend Stage：
+
+```sql
+CREATE STAGE IF NOT EXISTS wasm_udf_stage;
+PUT fs:///absolute/path/to/wasm_udf_example.wasm @wasm_udf_stage/;
+```
+
+### 4. 注册并使用函数
+
+`HANDLER` 填写 Rust 入口函数名（`wasm_gcd`），而不是 `#[function(...)]` 属性中的完整签名。
+
+```sql
+CREATE OR REPLACE FUNCTION wasm_gcd(INT, INT)
+RETURNS INT
+LANGUAGE wasm
+HANDLER = 'wasm_gcd'
+AS $$@wasm_udf_stage/wasm_udf_example.wasm$$;
+
+SELECT wasm_gcd(18, 24) AS result;
+```
+
+查询返回 `6`。
+
+:::note 迁移旧版 WASM UDF
+旧版 WASM UDF 使用完整导出签名，例如 `HANDLER = 'wasm_gcd(int4,int4)->int4'`。当前 Databend 版本只接受入口函数名：`HANDLER = 'wasm_gcd'`。
+
+迁移时，请使用兼容的 Arrow UDF 版本重新构建模块、上传新模块，并通过裸入口函数名执行 `CREATE OR REPLACE FUNCTION`。仅替换 Stage 中的文件并不足够，因为已有的函数元数据不会自动改写。
+:::

--- a/docs/cn/sql-reference/10-sql-commands/00-ddl/10-udf/index.md
+++ b/docs/cn/sql-reference/10-sql-commands/00-ddl/10-udf/index.md
@@ -12,7 +12,7 @@ Databend 中的用户自定义函数（User-Defined Function，UDF）允许您�
 
 | 命令 | 描述 |
 |---|---|
-| [CREATE SCALAR FUNCTION](ddl-create-function.md) | 标量函数（SQL/Python/JavaScript） |
+| [CREATE SCALAR FUNCTION](ddl-create-function.md) | 标量函数（SQL/Python/JavaScript/WASM） |
 | [CREATE AGGREGATE FUNCTION](ddl-create-aggregate-function.md) | 脚本 UDAF（JavaScript/Python 运行时） |
 | [CREATE TABLE FUNCTION](ddl-create-table-function.md) | 纯 SQL 表函数（返回结果集） |
 | [SHOW USER FUNCTIONS](ddl-show-user-functions.md) | 列出所有用户自定义函数 |
@@ -21,10 +21,10 @@ Databend 中的用户自定义函数（User-Defined Function，UDF）允许您�
 
 ## 函数类型对比
 
-| 特性 | 标量（SQL） | 标量（Python/JavaScript） | 聚合（脚本） | 表格（SQL） |
+| 特性 | 标量（SQL） | 标量（Python/JavaScript/WASM） | 聚合（脚本） | 表格（SQL） |
 |---|---|---|---|---|
 | **返回类型** | 单个值 | 单个值 | 单个值 | 表/结果集 |
-| **语言** | SQL 表达式 | Python/JavaScript | JavaScript/Python 运行时 | SQL 查询 |
+| **语言** | SQL 表达式 | Python/JavaScript/WASM | JavaScript/Python 运行时 | SQL 查询 |
 | **性能** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
 | **需要企业版** | 否 | Python 运行时需要 | Python 运行时需要 | 否 |
 | **包支持** | 否 | Python：支持 PACKAGES | Python：支持 PACKAGES | 否 |
@@ -45,4 +45,9 @@ CREATE FUNCTION func_name(param TYPE) RETURNS TABLE(...) AS $$ query $$;
 CREATE FUNCTION func_name(param TYPE) RETURNS TYPE
 LANGUAGE python
 HANDLER = 'handler' AS $$ code $$;
+
+-- 标量函数（Stage 中的 WASM 模块）
+CREATE OR REPLACE FUNCTION func_name(param TYPE) RETURNS TYPE
+LANGUAGE wasm
+HANDLER = 'handler' AS $$@stage/module.wasm$$;
 ```

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/10-udf/ddl-create-function.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/10-udf/ddl-create-function.md
@@ -4,12 +4,13 @@ sidebar_position: 0
 ---
 import FunctionDescription from '@site/src/components/FunctionDescription';
 
-<FunctionDescription description="Introduced or updated: SQL v1.2.799; Python/JavaScript v1.2.339"/>
+<FunctionDescription description="Introduced or updated: SQL v1.2.799; Python/JavaScript v1.2.339; WASM v1.2.936"/>
 
-Creates a scalar user-defined function (Scalar UDF). The same `CREATE FUNCTION` statement supports two implementation styles:
+Creates a scalar user-defined function (Scalar UDF). The same `CREATE FUNCTION` statement supports three implementation styles:
 
 - **SQL expression**: Logic expressed purely in SQL; no external runtime is required.
 - **Python / JavaScript**: Write code and specify the entry point with `HANDLER`.
+- **WebAssembly (WASM)**: Compile a Rust function into a WASM module, upload it to a stage, and specify its entry point with `HANDLER`.
 
 If you need to call external systems (HTTP/services), see External Function commands.
 
@@ -39,15 +40,28 @@ CREATE [ OR REPLACE ] FUNCTION [ IF NOT EXISTS ] <function_name>
     [ DESC='<description>' ]
 ```
 
+### WebAssembly (WASM)
+
+```sql
+CREATE [ OR REPLACE ] FUNCTION [ IF NOT EXISTS ] <function_name>
+    ( [<parameter_list>] )
+    RETURNS <return_type>
+    LANGUAGE wasm
+    HANDLER = '<handler_name>'
+    AS $$<stage_path>$$
+    [ DESC='<description>' ]
+```
+
 ## Parameters
 
 - `<parameter_list>`: Optional comma-separated list of parameters with their types (e.g., `x INT, y FLOAT`)
 - `<return_type>`: The data type of the function's return value
-- `<language>`: `python`, `javascript`
-- `<import_path>`: Stage files to import (e.g., `@s_udf/your_file.zip`)
-- `<package_name>`: Packages to install from PyPI (Python only; e.g. `numpy`)
-- `<handler_name>`: Name of the function in the code to call
-- `<function_code>`: Implementation code in the specified language
+- `<language>`: `python`, `javascript`, or `wasm`
+- `<import_path>`: Stage files to import for Python or JavaScript (e.g., `@s_udf/your_file.zip`)
+- `<package_name>`: Packages to install from PyPI (Python only; e.g., `numpy`)
+- `<handler_name>`: Name of the function to call. For WASM, use only the Rust entry-point name, not a full Arrow UDF signature.
+- `<function_code>`: Python or JavaScript implementation code
+- `<stage_path>`: Path to the compiled WASM module in a stage (e.g., `@wasm_udf_stage/wasm_udf_example.wasm`)
 
 ## Access control requirements
 
@@ -187,6 +201,90 @@ export function calculateAge(birthDateStr) {
 }
 $$;
 ```
+
+## WebAssembly (WASM)
+
+WASM UDFs let you implement scalar functions in Rust and run the compiled module directly in Databend. The module must use an Arrow UDF version compatible with your Databend release.
+
+The following example builds and registers a greatest common divisor function.
+
+### 1. Create the Rust project
+
+Install the WASI Preview 1 target and create a library crate:
+
+```bash
+rustup target add wasm32-wasip1
+cargo new --lib wasm-udf-example
+cd wasm-udf-example
+```
+
+`wasm32-wasip1` is the current name of the Rust target previously called `wasm32-wasi`.
+
+Replace `Cargo.toml` with the following configuration. The pinned Arrow UDF revision matches Databend v1.2.936:
+
+```toml
+[package]
+name = "wasm-udf-example"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+arrow-udf = { git = "https://github.com/datafuse-extras/arrow-udf.git", rev = "c1de708add62ecd1afa2721b2e5c639f29be1f9d" }
+```
+
+### 2. Implement the function
+
+Replace `src/lib.rs` with:
+
+```rust
+use arrow_udf::function;
+
+#[function("wasm_gcd(int, int) -> int")]
+fn wasm_gcd(mut a: i32, mut b: i32) -> i32 {
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}
+```
+
+### 3. Build and upload the module
+
+```bash
+cargo build --release --target wasm32-wasip1
+```
+
+The compiled module is created at `target/wasm32-wasip1/release/wasm_udf_example.wasm`. Upload it to a Databend stage with an absolute local path:
+
+```sql
+CREATE STAGE IF NOT EXISTS wasm_udf_stage;
+PUT fs:///absolute/path/to/wasm_udf_example.wasm @wasm_udf_stage/;
+```
+
+### 4. Register and use the function
+
+`HANDLER` is the Rust entry-point name (`wasm_gcd`), not the complete signature in the `#[function(...)]` attribute.
+
+```sql
+CREATE OR REPLACE FUNCTION wasm_gcd(INT, INT)
+RETURNS INT
+LANGUAGE wasm
+HANDLER = 'wasm_gcd'
+AS $$@wasm_udf_stage/wasm_udf_example.wasm$$;
+
+SELECT wasm_gcd(18, 24) AS result;
+```
+
+The query returns `6`.
+
+:::note Migrating an older WASM UDF
+Legacy WASM UDFs used a full exported signature such as `HANDLER = 'wasm_gcd(int4,int4)->int4'`. Current Databend versions require only the entry-point name: `HANDLER = 'wasm_gcd'`.
+
+To migrate, rebuild the module with a compatible Arrow UDF version, upload the rebuilt module, and run `CREATE OR REPLACE FUNCTION` with the bare handler name. Updating only the staged file is insufficient because existing function metadata is not rewritten automatically.
+:::
 
 ## Worker Management for UDFs
 

--- a/docs/en/sql-reference/10-sql-commands/00-ddl/10-udf/index.md
+++ b/docs/en/sql-reference/10-sql-commands/00-ddl/10-udf/index.md
@@ -12,7 +12,7 @@ User-Defined Functions (UDFs) in Databend allow you to create custom operations 
 
 | Command | Description |
 |---------|-------------|
-| [CREATE SCALAR FUNCTION](ddl-create-function.md) | Scalar UDF (SQL/Python/JavaScript) |
+| [CREATE SCALAR FUNCTION](ddl-create-function.md) | Scalar UDF (SQL/Python/JavaScript/WASM) |
 | [CREATE AGGREGATE FUNCTION](ddl-create-aggregate-function.md) | Script UDAF (JavaScript/Python runtimes) |
 | [CREATE TABLE FUNCTION](ddl-create-table-function.md) | SQL-only table function returning result sets |
 | [SHOW USER FUNCTIONS](ddl-show-user-functions.md) | Lists all user-defined functions |
@@ -21,10 +21,10 @@ User-Defined Functions (UDFs) in Databend allow you to create custom operations 
 
 ## Function Type Comparison
 
-| Feature | Scalar (SQL) | Scalar (Python/JavaScript) | Aggregate (Script) | Tabular SQL |
+| Feature | Scalar (SQL) | Scalar (Python/JavaScript/WASM) | Aggregate (Script) | Tabular SQL |
 |---------|-------------|----------------------------|--------------------|------------|
 | **Return Type** | Single value | Single value | Single value | Table/ResultSet |
-| **Language** | SQL expressions | Python/JavaScript | JavaScript/Python runtimes | SQL queries |
+| **Language** | SQL expressions | Python/JavaScript/WASM | JavaScript/Python runtimes | SQL queries |
 | **Performance** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
 | **Enterprise Required** | No | Python runtime only | Python runtime only | No |
 | **Package Support** | No | Python: Yes (PACKAGES) | Python: Yes (PACKAGES) | No |
@@ -45,4 +45,9 @@ CREATE FUNCTION func_name(param TYPE) RETURNS TABLE(...) AS $$ query $$;
 CREATE FUNCTION func_name(param TYPE) RETURNS TYPE
 LANGUAGE python
 HANDLER = 'handler' AS $$ code $$;
+
+-- Scalar Function (WASM module in a stage)
+CREATE OR REPLACE FUNCTION func_name(param TYPE) RETURNS TYPE
+LANGUAGE wasm
+HANDLER = 'handler' AS $$@stage/module.wasm$$;
 ```


### PR DESCRIPTION
## Motivation

Databend PR [databendlabs/databend#20404](https://github.com/databendlabs/databend/pull/20404) restored native WASM UDF execution and established the current bare entry-point `HANDLER` convention. The dedicated WASM documentation had previously been removed during scalar UDF consolidation, so users no longer had a current end-to-end workflow or migration guidance.

## Summary

- Add WASM as a supported scalar UDF implementation in the current consolidated UDF reference.
- Document the Rust/Arrow UDF workflow from project setup through stage upload, registration, and execution.
- Clarify that `HANDLER` must contain only the Rust entry-point name.
- Add migration guidance for legacy full-signature handlers and older Arrow UDF modules.
- Update the UDF overview and unified syntax examples.

## Languages

- [x] English (`docs/en/`)
- [x] Chinese (`docs/cn/`)

## Testing

- [x] `npm run build:en`
- [x] `npm run build:cn`
- [x] `git diff --check`
- [x] WASM registration syntax and execution behavior cross-checked against the merged source PR's passing `udf_native` sqllogictest
- [x] Expected GCD result verified against the documented Rust implementation

## Related

- Source PR: https://github.com/databendlabs/databend/pull/20404
